### PR TITLE
Auth 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,11 @@ dependencies {
 
     // Swagger
     implementation "org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0"
+
+    // JWT
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 tasks.named('test') {

--- a/src/main/java/dooya/see/auth/application/AuthService.java
+++ b/src/main/java/dooya/see/auth/application/AuthService.java
@@ -1,0 +1,5 @@
+package dooya.see.auth.application;
+
+public interface AuthService {
+    LoginResponse login(LoginRequest request);
+}

--- a/src/main/java/dooya/see/auth/application/AuthServiceImpl.java
+++ b/src/main/java/dooya/see/auth/application/AuthServiceImpl.java
@@ -1,0 +1,23 @@
+package dooya.see.auth.application;
+
+import dooya.see.auth.util.JwtUtil;
+import dooya.see.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthServiceImpl implements AuthService {
+
+    private final JwtUtil jwtUtil;
+    private final AuthValidator authValidator;
+
+    @Override
+    public LoginResponse login(LoginRequest request) {
+        User user = authValidator.validateEmailAndPassword(request.email(), request.password());
+
+        String accessToken = jwtUtil.createAccessToken(user.getId(), user.getEmail(), user.getRole());
+
+        return LoginResponse.from(user, accessToken);
+    }
+}

--- a/src/main/java/dooya/see/auth/application/AuthValidator.java
+++ b/src/main/java/dooya/see/auth/application/AuthValidator.java
@@ -1,0 +1,7 @@
+package dooya.see.auth.application;
+
+import dooya.see.user.domain.User;
+
+public interface AuthValidator {
+    User validateEmailAndPassword(String email, String password);
+}

--- a/src/main/java/dooya/see/auth/application/AuthValidatorImpl.java
+++ b/src/main/java/dooya/see/auth/application/AuthValidatorImpl.java
@@ -1,0 +1,24 @@
+package dooya.see.auth.application;
+
+import dooya.see.common.exception.CustomException;
+import dooya.see.common.exception.ErrorCode;
+import dooya.see.user.domain.User;
+import dooya.see.user.domain.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AuthValidatorImpl implements AuthValidator {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    public User validateEmailAndPassword(String email, String password) {
+        return userRepository.findByEmail(email)
+                .filter(user -> passwordEncoder.matches(password, user.getPassword()))
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_MATCH_LOGIN_INFO));
+    }
+}

--- a/src/main/java/dooya/see/auth/application/LoginRequest.java
+++ b/src/main/java/dooya/see/auth/application/LoginRequest.java
@@ -1,0 +1,4 @@
+package dooya.see.auth.application;
+
+public class LoginRequest {
+}

--- a/src/main/java/dooya/see/auth/application/LoginRequest.java
+++ b/src/main/java/dooya/see/auth/application/LoginRequest.java
@@ -1,4 +1,14 @@
 package dooya.see.auth.application;
 
-public class LoginRequest {
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+
+@Builder
+public record LoginRequest(
+        @NotBlank(message = "이메일은 비어 있을 수 없습니다")
+        String email,
+
+        @NotBlank(message = "비밀번호는 비어 있을 수 없습니다")
+        String password
+) {
 }

--- a/src/main/java/dooya/see/auth/application/LoginResponse.java
+++ b/src/main/java/dooya/see/auth/application/LoginResponse.java
@@ -1,0 +1,16 @@
+package dooya.see.auth.application;
+
+import lombok.Builder;
+
+import java.time.LocalDate;
+
+@Builder
+public record LoginResponse(
+        String accessToken,
+        Long id,
+        String email,
+        String name,
+        LocalDate birthDate,
+        String phoneNumber
+) {
+}

--- a/src/main/java/dooya/see/auth/application/LoginResponse.java
+++ b/src/main/java/dooya/see/auth/application/LoginResponse.java
@@ -1,6 +1,5 @@
 package dooya.see.auth.application;
 
-import dooya.see.user.application.UserSignUpResponse;
 import dooya.see.user.domain.User;
 import lombok.Builder;
 

--- a/src/main/java/dooya/see/auth/application/LoginResponse.java
+++ b/src/main/java/dooya/see/auth/application/LoginResponse.java
@@ -1,5 +1,7 @@
 package dooya.see.auth.application;
 
+import dooya.see.user.application.UserSignUpResponse;
+import dooya.see.user.domain.User;
 import lombok.Builder;
 
 import java.time.LocalDate;
@@ -13,4 +15,15 @@ public record LoginResponse(
         LocalDate birthDate,
         String phoneNumber
 ) {
+
+    public static LoginResponse from(User user, String accessToken) {
+        return LoginResponse.builder()
+                .accessToken(accessToken)
+                .id(user.getId())
+                .email(user.getEmail())
+                .name(user.getName())
+                .birthDate(user.getBirthDate())
+                .phoneNumber(user.getPhoneNumber())
+                .build();
+    }
 }

--- a/src/main/java/dooya/see/auth/config/SecurityConfig.java
+++ b/src/main/java/dooya/see/auth/config/SecurityConfig.java
@@ -34,6 +34,7 @@ public class SecurityConfig {
         // 경로별 인가 작업
         http.authorizeHttpRequests((auth) -> auth
                 .requestMatchers("/api/users/**").permitAll()
+                .requestMatchers("/api/auth/**").permitAll()
                 .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html", "/webjars/**").permitAll()
                 .anyRequest().authenticated());
 

--- a/src/main/java/dooya/see/auth/domain/LoginUser.java
+++ b/src/main/java/dooya/see/auth/domain/LoginUser.java
@@ -2,15 +2,17 @@ package dooya.see.auth.domain;
 
 import dooya.see.user.domain.Role;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
 import java.util.Collection;
+import java.util.Collections;
 
 public record LoginUser(Long id, String email, String role) implements UserDetails {
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return null;
+        return Collections.singleton(new SimpleGrantedAuthority("ROLE_" + role));
     }
 
     public Role getRole() {

--- a/src/main/java/dooya/see/auth/domain/LoginUser.java
+++ b/src/main/java/dooya/see/auth/domain/LoginUser.java
@@ -1,0 +1,29 @@
+package dooya.see.auth.domain;
+
+import dooya.see.user.domain.Role;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+
+public record LoginUser(Long id, String email, String role) implements UserDetails {
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return null;
+    }
+
+    public Role getRole() {
+        return Role.of(role);
+    }
+
+    @Override
+    public String getPassword() {
+        return "";
+    }
+
+    @Override
+    public String getUsername() {
+        return email;
+    }
+}

--- a/src/main/java/dooya/see/auth/exception/CustomAccessDeniedHandler.java
+++ b/src/main/java/dooya/see/auth/exception/CustomAccessDeniedHandler.java
@@ -1,0 +1,27 @@
+package dooya.see.auth.exception;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dooya.see.common.exception.ErrorResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException {
+        response.setContentType("application/json;charset=UTF-8");
+        String result = objectMapper.writeValueAsString(ErrorResponse.of("접근 권한이 없는 사용자입니다."));
+        response.setStatus(403);
+        response.getWriter().write(result);
+    }
+}

--- a/src/main/java/dooya/see/auth/exception/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/dooya/see/auth/exception/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,27 @@
+package dooya.see.auth.exception;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dooya.see.common.exception.ErrorResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
+        response.setContentType("application/json;charset=UTF-8");
+        String result = objectMapper.writeValueAsString(ErrorResponse.of("인증에 실패하였습니다. 다시 로그인 해주세요."));
+        response.setStatus(401);
+        response.getWriter().write(result);
+    }
+}

--- a/src/main/java/dooya/see/auth/filter/JwtAuthFilter.java
+++ b/src/main/java/dooya/see/auth/filter/JwtAuthFilter.java
@@ -22,7 +22,9 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static dooya.see.common.exception.ErrorCode.UNKNOWN_TOKEN_ERROR;
 
@@ -93,8 +95,10 @@ public class JwtAuthFilter extends OncePerRequestFilter {
     }
 
     private void setResponse(HttpServletResponse response, ErrorCode errorCode) throws IOException {
-        response.setContentType("application/json;charset=UTF-8");
-        response.setStatus(errorCode.getStatus().value());
-        response.getWriter().print(objectMapper.writeValueAsString(errorCode.getMessage()));
+        Map<String, Object> errorResponse = new HashMap<>();
+        errorResponse.put("code", errorCode.name());
+        errorResponse.put("message", errorCode.getMessage());
+        errorResponse.put("status", errorCode.getStatus().value());
+        response.getWriter().print(objectMapper.writeValueAsString(errorResponse));
     }
 }

--- a/src/main/java/dooya/see/auth/filter/JwtAuthFilter.java
+++ b/src/main/java/dooya/see/auth/filter/JwtAuthFilter.java
@@ -1,0 +1,100 @@
+package dooya.see.auth.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dooya.see.auth.domain.LoginUser;
+import dooya.see.auth.util.CookieUtil;
+import dooya.see.auth.util.JwtUtil;
+import dooya.see.common.exception.CustomException;
+import dooya.see.common.exception.ErrorCode;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+
+import static dooya.see.common.exception.ErrorCode.UNKNOWN_TOKEN_ERROR;
+
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        try {
+            String token = CookieUtil.findToken(request);
+
+            if (!verifyToken(request, token)) {
+                filterChain.doFilter(request, response);
+                return;
+            }
+
+            LoginUser loginUser = getUser(token);
+            setSecuritySession(loginUser);
+            filterChain.doFilter(request, response);
+        } catch (CustomException e) {
+            ErrorCode errorCode = e.getErrorCode();
+            switch (errorCode) {
+                case WRONG_TYPE_TOKEN, UNSUPPORTED_TOKEN, EXPIRED_TOKEN, UNKNOWN_TOKEN_ERROR ->
+                        setResponse(response, errorCode);
+                default -> {
+                    log.error("알 수 없는 에러 코드: {}", errorCode);
+                    setResponse(response, UNKNOWN_TOKEN_ERROR); // 기본 예외 처리
+                }
+            }
+        }
+    }
+
+    private static void setSecuritySession(LoginUser loginUser) {
+        log.info("SessionLoginUser: {}", loginUser.getUsername());
+
+        Collection<GrantedAuthority> authorities = List.of(new SimpleGrantedAuthority(loginUser.getRole().getRoleSecurity()));
+
+        Authentication authToken = new UsernamePasswordAuthenticationToken(loginUser, null, authorities);
+        SecurityContextHolder.getContext().setAuthentication(authToken);
+    }
+
+    private LoginUser getUser(String token) {
+        Long userId = jwtUtil.getUserId(token);
+        String email = jwtUtil.getUsername(token);
+        String role = jwtUtil.getRole(token);
+
+        return new LoginUser(userId, email, role);
+    }
+
+    private boolean verifyToken(HttpServletRequest request, String token) {
+        Boolean isValid = (Boolean) request.getAttribute("isTokenValid");
+        if (isValid != null) return isValid;
+
+        if (token == null || !jwtUtil.validateToken(token)) {
+            log.debug("token null or not validate");
+            request.setAttribute("isTokenValid", false);
+            return false;
+        }
+
+        request.setAttribute("isTokenValid", true);
+        return true;
+    }
+
+    private void setResponse(HttpServletResponse response, ErrorCode errorCode) throws IOException {
+        response.setContentType("application/json;charset=UTF-8");
+        response.setStatus(errorCode.getStatus().value());
+        response.getWriter().print(objectMapper.writeValueAsString(errorCode.getMessage()));
+    }
+}

--- a/src/main/java/dooya/see/auth/presentation/AuthController.java
+++ b/src/main/java/dooya/see/auth/presentation/AuthController.java
@@ -1,0 +1,40 @@
+package dooya.see.auth.presentation;
+
+import dooya.see.auth.application.AuthService;
+import dooya.see.auth.application.LoginRequest;
+import dooya.see.auth.application.LoginResponse;
+import dooya.see.auth.util.CookieUtil;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    @Value("${cookie.valid-time}")
+    private long COOKIE_VALID_TIME;
+
+    @Value("${cookie.name}")
+    private String COOKIE_NAME;
+
+    private final AuthService authService;
+
+    @PostMapping("/login")
+    public ResponseEntity<LoginResponse> userLogin(@Valid @RequestBody LoginRequest request) {
+        LoginResponse response = authService.login(request);
+        ResponseCookie cookie = CookieUtil.createCookie(COOKIE_NAME, response.accessToken(), COOKIE_VALID_TIME);
+
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, cookie.toString())
+                .body(response);
+    }
+}

--- a/src/main/java/dooya/see/auth/util/CookieUtil.java
+++ b/src/main/java/dooya/see/auth/util/CookieUtil.java
@@ -1,0 +1,34 @@
+package dooya.see.auth.util;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.ResponseCookie;
+
+public class CookieUtil {
+
+    public static ResponseCookie createCookie(String name, String value, long cookieExpiration) {
+        return ResponseCookie.from(name, value)
+                .maxAge(cookieExpiration)
+                .path("/")
+                .sameSite("None")
+                .secure(true)
+                .httpOnly(true)
+                .build();
+    }
+
+    public static String findToken(HttpServletRequest request) {
+        String token = null;
+        Cookie[] cookies = request.getCookies();
+
+        if (cookies == null) {
+            return null;
+        }
+
+        for (Cookie cookie : cookies) {
+            if (cookie.getName().equals("Authorization")) {
+                token = cookie.getValue();
+            }
+        }
+        return token;
+    }
+}

--- a/src/main/java/dooya/see/auth/util/JwtUtil.java
+++ b/src/main/java/dooya/see/auth/util/JwtUtil.java
@@ -46,19 +46,21 @@ public class JwtUtil {
                 .compact();
     }
 
-    public Long getUserId(String token) {
+    private Claims getClaims(String token) {
         return Jwts.parserBuilder().setSigningKey(secretKey).build()
-                .parseClaimsJws(token).getBody().get("userId", Long.class);
+                .parseClaimsJws(token).getBody();
+    }
+
+    public Long getUserId(String token) {
+        return getClaims(token).get("userId", Long.class);
     }
 
     public String getUsername(String token) {
-        return Jwts.parserBuilder().setSigningKey(secretKey).build()
-                .parseClaimsJws(token).getBody().get("email", String.class);
+        return getClaims(token).get("email", String.class);
     }
 
     public String getRole(String token) {
-        return Jwts.parserBuilder().setSigningKey(secretKey).build()
-                .parseClaimsJws(token).getBody().get("role", String.class);
+        return getClaims(token).get("role", String.class);
     }
 
     public boolean validateToken(String token) {

--- a/src/main/java/dooya/see/auth/util/JwtUtil.java
+++ b/src/main/java/dooya/see/auth/util/JwtUtil.java
@@ -1,0 +1,86 @@
+package dooya.see.auth.util;
+
+
+import dooya.see.common.exception.CustomException;
+import dooya.see.common.exception.ErrorCode;
+import dooya.see.user.domain.Role;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
+import jakarta.annotation.PostConstruct;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+@Component
+public class JwtUtil {
+
+    private SecretKey secretKey;
+
+    @Value("${jwt.secret-key}")
+    private String secret;
+
+    @Value("${jwt.valid-time}")
+    private long TOKEN_VALID_TIME;
+
+    @PostConstruct
+    private void init() {
+        this.secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+    }
+
+    public String createAccessToken(Long userId, String email, Role role) {
+        Date timeNow = new Date(System.currentTimeMillis());
+        Date expirationTime = new Date(timeNow.getTime() + TOKEN_VALID_TIME);
+
+        return Jwts.builder()
+                .claim("userId", userId)
+                .claim("email", email)
+                .claim("role", role.getRoleSecurity())
+                .setIssuedAt(timeNow)
+                .setExpiration(expirationTime)
+                .signWith(secretKey)
+                .compact();
+    }
+
+    public Long getUserId(String token) {
+        return Jwts.parserBuilder().setSigningKey(secretKey).build()
+                .parseClaimsJws(token).getBody().get("userId", Long.class);
+    }
+
+    public String getUsername(String token) {
+        return Jwts.parserBuilder().setSigningKey(secretKey).build()
+                .parseClaimsJws(token).getBody().get("email", String.class);
+    }
+
+    public String getRole(String token) {
+        return Jwts.parserBuilder().setSigningKey(secretKey).build()
+                .parseClaimsJws(token).getBody().get("role", String.class);
+    }
+
+    public boolean validateToken(String token) {
+        return valid(secretKey, token);
+    }
+
+    private boolean valid(SecretKey secretKey, String token) {
+        if (token == null) {
+            throw new CustomException(ErrorCode.MISSING_TOKEN);
+        }
+        try {
+            Jws<Claims> claims = Jwts.parserBuilder().setSigningKey(secretKey).build()
+                    .parseClaimsJws(token);
+            return !claims.getBody().getExpiration().before(new Date());
+        } catch (SignatureException ex) {
+            throw new CustomException(ErrorCode.WRONG_TYPE_TOKEN);
+        } catch (MalformedJwtException ex) {
+            throw new CustomException(ErrorCode.UNSUPPORTED_TOKEN);
+        } catch (ExpiredJwtException ex) {
+            throw new CustomException(ErrorCode.EXPIRED_TOKEN);
+        } catch (IllegalArgumentException ex) {
+            throw new CustomException(ErrorCode.UNKNOWN_TOKEN_ERROR);
+        }
+    }
+}

--- a/src/main/java/dooya/see/common/exception/ErrorCode.java
+++ b/src/main/java/dooya/see/common/exception/ErrorCode.java
@@ -28,10 +28,7 @@ public enum ErrorCode {
     UNSUPPORTED_TOKEN(HttpStatus.UNAUTHORIZED, "지원하지 않는 토큰 형식입니다."),
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),
     UNKNOWN_TOKEN_ERROR(HttpStatus.BAD_REQUEST, "토큰 값이 존재하지 않습니다."),
-    MISSING_TOKEN(HttpStatus.BAD_REQUEST, "토큰이 누락되었습니다."),
-
-    // Common
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "예상치 못한 서버 오류가 발생했습니다.");
+    MISSING_TOKEN(HttpStatus.BAD_REQUEST, "토큰이 누락되었습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/dooya/see/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/dooya/see/common/exception/GlobalExceptionHandler.java
@@ -66,15 +66,6 @@ public class GlobalExceptionHandler {
                 .body(ErrorResponse.of(errorMessage));
     }
 
-    @ExceptionHandler(Exception.class)
-    public ResponseEntity<ErrorResponse> handleUnhandledException(Exception ex) {
-        logException("UnhandledException", ex);
-        ErrorCode errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
-        return ResponseEntity
-                .status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(ErrorResponse.of(errorCode.getMessage()));
-    }
-
     private void logException(String title, Exception ex) {
         log.error("[{}] 예외 발생: {}", title, ex.getMessage(), ex);
     }

--- a/src/test/java/dooya/see/auth/application/AuthServiceTest.java
+++ b/src/test/java/dooya/see/auth/application/AuthServiceTest.java
@@ -1,0 +1,74 @@
+package dooya.see.auth.application;
+
+import dooya.see.auth.util.JwtUtil;
+import dooya.see.common.AuthFixture;
+import dooya.see.common.UserFixture;
+import dooya.see.common.exception.CustomException;
+import dooya.see.common.exception.ErrorCode;
+import dooya.see.user.domain.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+
+@ExtendWith(MockitoExtension.class)
+public class AuthServiceTest {
+
+    @InjectMocks
+    private AuthServiceImpl authService;
+
+    @Mock
+    private AuthValidator authValidator;
+
+    @Mock
+    private JwtUtil jwtUtil;
+
+    private LoginRequest request;
+    private User testUser;
+
+    @BeforeEach
+    void setUp() {
+        request = AuthFixture.request();
+        testUser = UserFixture.testUser();
+    }
+
+    @DisplayName("유저 로그인 성공 단위테스트")
+    @Test
+    void user_login_success() {
+        // Arrange
+        given(authValidator.validateEmailAndPassword(request.email(), request.password())).willReturn(testUser);
+        given(jwtUtil.createAccessToken(testUser.getId(), testUser.getEmail(), testUser.getRole())).willReturn("mocked-jwt-token");
+
+        // Act
+        LoginResponse response = authService.login(request);
+
+        // Assert
+        assertThat(response.email()).isEqualTo(testUser.getEmail());
+        assertThat(response.accessToken()).isEqualTo("mocked-jwt-token");
+
+        then(authValidator).should(times(1)).validateEmailAndPassword(request.email(), request.password());
+        then(jwtUtil).should(times(1)).createAccessToken(testUser.getId(), testUser.getEmail(), testUser.getRole());
+    }
+
+    @DisplayName("유저 로그인 실패 단위테스트")
+    @Test
+    void user_login_failNotEmail() {
+        // Arrange
+        doThrow(new CustomException(ErrorCode.USER_NOT_MATCH_LOGIN_INFO)).when(authValidator).validateEmailAndPassword(request.email(), request.password());
+
+        // Act && Assert
+        assertThrows(CustomException.class, () -> authService.login(request));
+
+        then(authValidator).should(times(1)).validateEmailAndPassword(request.email(), request.password());
+    }
+}

--- a/src/test/java/dooya/see/auth/application/AuthServiceTest.java
+++ b/src/test/java/dooya/see/auth/application/AuthServiceTest.java
@@ -15,6 +15,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
@@ -67,7 +68,9 @@ public class AuthServiceTest {
         doThrow(new CustomException(ErrorCode.USER_NOT_MATCH_LOGIN_INFO)).when(authValidator).validateEmailAndPassword(request.email(), request.password());
 
         // Act && Assert
-        assertThrows(CustomException.class, () -> authService.login(request));
+        assertThatCode(() -> authService.login(request))
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining("로그인 정보가 일치하지 않습니다.");
 
         then(authValidator).should(times(1)).validateEmailAndPassword(request.email(), request.password());
     }

--- a/src/test/java/dooya/see/auth/presentation/AuthControllerTest.java
+++ b/src/test/java/dooya/see/auth/presentation/AuthControllerTest.java
@@ -6,8 +6,12 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -23,6 +27,10 @@ public class AuthControllerTest {
     @DisplayName("유저 로그인 성공 테스트")
     @Test
     void user_login_success() throws Exception {
-
+        // Act & Assert
+        mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk());
     }
 }

--- a/src/test/java/dooya/see/auth/presentation/AuthControllerTest.java
+++ b/src/test/java/dooya/see/auth/presentation/AuthControllerTest.java
@@ -28,8 +28,10 @@ public class AuthControllerTest {
     @DisplayName("유저 로그인 성공 테스트")
     @Test
     void user_login_success() throws Exception {
+        // Arrange
+        LoginRequest request = new LoginRequest("test@see.com", "testPassword");
+
         // Act & Assert
-        LoginRequest request;
         mockMvc.perform(post("/api/auth/login")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))

--- a/src/test/java/dooya/see/auth/presentation/AuthControllerTest.java
+++ b/src/test/java/dooya/see/auth/presentation/AuthControllerTest.java
@@ -11,6 +11,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
+import static dooya.see.common.AuthFixture.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -29,7 +30,7 @@ public class AuthControllerTest {
     @Test
     void user_login_success() throws Exception {
         // Arrange
-        LoginRequest request = new LoginRequest("test@see.com", "testPassword");
+        LoginRequest request = request();
 
         // Act & Assert
         mockMvc.perform(post("/api/auth/login")

--- a/src/test/java/dooya/see/auth/presentation/AuthControllerTest.java
+++ b/src/test/java/dooya/see/auth/presentation/AuthControllerTest.java
@@ -33,12 +33,9 @@ public class AuthControllerTest {
     @Autowired
     private UserJpaRepository userJpaRepository;
 
-    @Autowired
-    private PasswordEncoder passwordEncoder;
-
     @BeforeEach
     void setUp() {
-        userJpaRepository.save(UserFixture.testUser(passwordEncoder));
+        userJpaRepository.save(UserFixture.testUser());
     }
 
     @DisplayName("유저 로그인 성공 테스트")

--- a/src/test/java/dooya/see/auth/presentation/AuthControllerTest.java
+++ b/src/test/java/dooya/see/auth/presentation/AuthControllerTest.java
@@ -1,0 +1,20 @@
+package dooya.see.auth.presentation;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+public class AuthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+}

--- a/src/test/java/dooya/see/auth/presentation/AuthControllerTest.java
+++ b/src/test/java/dooya/see/auth/presentation/AuthControllerTest.java
@@ -1,6 +1,7 @@
 package dooya.see.auth.presentation;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import dooya.see.auth.application.LoginRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,6 +29,7 @@ public class AuthControllerTest {
     @Test
     void user_login_success() throws Exception {
         // Act & Assert
+        LoginRequest request;
         mockMvc.perform(post("/api/auth/login")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))

--- a/src/test/java/dooya/see/auth/presentation/AuthControllerTest.java
+++ b/src/test/java/dooya/see/auth/presentation/AuthControllerTest.java
@@ -2,12 +2,16 @@ package dooya.see.auth.presentation;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dooya.see.auth.application.LoginRequest;
+import dooya.see.common.UserFixture;
+import dooya.see.user.infrastructure.UserJpaRepository;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -25,6 +29,17 @@ public class AuthControllerTest {
 
     @Autowired
     private ObjectMapper objectMapper;
+
+    @Autowired
+    private UserJpaRepository userJpaRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @BeforeEach
+    void setUp() {
+        userJpaRepository.save(UserFixture.testUser(passwordEncoder));
+    }
 
     @DisplayName("유저 로그인 성공 테스트")
     @Test

--- a/src/test/java/dooya/see/auth/presentation/AuthControllerTest.java
+++ b/src/test/java/dooya/see/auth/presentation/AuthControllerTest.java
@@ -13,6 +13,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static dooya.see.common.AuthFixture.*;
@@ -22,6 +23,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
+@Sql("classpath:init.sql")
 public class AuthControllerTest {
 
     @Autowired
@@ -33,9 +35,12 @@ public class AuthControllerTest {
     @Autowired
     private UserJpaRepository userJpaRepository;
 
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
     @BeforeEach
     void setUp() {
-        userJpaRepository.save(UserFixture.testUser());
+        userJpaRepository.save(UserFixture.mockUser(passwordEncoder));
     }
 
     @DisplayName("유저 로그인 성공 테스트")

--- a/src/test/java/dooya/see/auth/presentation/AuthControllerTest.java
+++ b/src/test/java/dooya/see/auth/presentation/AuthControllerTest.java
@@ -1,6 +1,8 @@
 package dooya.see.auth.presentation;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -17,4 +19,10 @@ public class AuthControllerTest {
 
     @Autowired
     private ObjectMapper objectMapper;
+
+    @DisplayName("유저 로그인 성공 테스트")
+    @Test
+    void user_login_success() throws Exception {
+
+    }
 }

--- a/src/test/java/dooya/see/common/AuthFixture.java
+++ b/src/test/java/dooya/see/common/AuthFixture.java
@@ -5,6 +5,6 @@ import dooya.see.auth.application.LoginRequest;
 public class AuthFixture {
 
     public static LoginRequest request() {
-        return new LoginRequest("test@see.com", "testName");
+        return new LoginRequest("test@see.com", "testPassword");
     }
 }

--- a/src/test/java/dooya/see/common/AuthFixture.java
+++ b/src/test/java/dooya/see/common/AuthFixture.java
@@ -1,0 +1,10 @@
+package dooya.see.common;
+
+import dooya.see.auth.application.LoginRequest;
+
+public class AuthFixture {
+
+    public static LoginRequest request() {
+        return new LoginRequest("test@see.com", "testName");
+    }
+}

--- a/src/test/java/dooya/see/common/UserFixture.java
+++ b/src/test/java/dooya/see/common/UserFixture.java
@@ -37,4 +37,15 @@ public class UserFixture {
                 .role(Role.of("USER"))
                 .build();
     }
+
+    public static User mockUser(PasswordEncoder passwordEncoder) {
+        return User.builder()
+                .email("test@see.com")
+                .name("testName")
+                .password(passwordEncoder.encode("testPassword"))
+                .birthDate(LocalDate.of(2001, 1, 4))
+                .phoneNumber("01012345678")
+                .role(Role.of("USER"))
+                .build();
+    }
 }

--- a/src/test/java/dooya/see/common/UserFixture.java
+++ b/src/test/java/dooya/see/common/UserFixture.java
@@ -3,11 +3,12 @@ package dooya.see.common;
 import dooya.see.user.application.UserSignUpRequest;
 import dooya.see.user.domain.Role;
 import dooya.see.user.domain.User;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDate;
 
-public class UserSignUpFixture {
+public class UserFixture {
 
     public static UserSignUpRequest request() {
         return new UserSignUpRequest("test@see.com", "testName", "testPassword", LocalDate.of(2001, 1, 4), "01012345678");
@@ -24,5 +25,16 @@ public class UserSignUpFixture {
         );
         ReflectionTestUtils.setField(testUser, "id", 1L);
         return testUser;
+    }
+
+    public static User testUser(PasswordEncoder passwordEncoder) {
+        return User.builder()
+                .email("test@see.com")
+                .name("testName")
+                .password(passwordEncoder.encode("testPassword"))
+                .birthDate(LocalDate.of(2001, 1, 4))
+                .phoneNumber("01012345678")
+                .role(Role.of("USER"))
+                .build();
     }
 }

--- a/src/test/java/dooya/see/common/UserFixture.java
+++ b/src/test/java/dooya/see/common/UserFixture.java
@@ -27,11 +27,11 @@ public class UserFixture {
         return testUser;
     }
 
-    public static User testUser(PasswordEncoder passwordEncoder) {
+    public static User testUser() {
         return User.builder()
                 .email("test@see.com")
                 .name("testName")
-                .password(passwordEncoder.encode("testPassword"))
+                .password("$2a$10$DOWSDdkg2YqXWB3S1.CzHeeI6qHtDc0lYBFfN4y3pFehUcbDoztYm")
                 .birthDate(LocalDate.of(2001, 1, 4))
                 .phoneNumber("01012345678")
                 .role(Role.of("USER"))

--- a/src/test/java/dooya/see/common/UserSignUpFixture.java
+++ b/src/test/java/dooya/see/common/UserSignUpFixture.java
@@ -1,4 +1,4 @@
-package dooya.see.user.fixture;
+package dooya.see.common;
 
 import dooya.see.user.application.UserSignUpRequest;
 import dooya.see.user.domain.Role;

--- a/src/test/java/dooya/see/user/application/UserSignUpServiceTest.java
+++ b/src/test/java/dooya/see/user/application/UserSignUpServiceTest.java
@@ -5,7 +5,7 @@ import dooya.see.common.exception.ErrorCode;
 import dooya.see.user.domain.Role;
 import dooya.see.user.domain.User;
 import dooya.see.user.domain.UserRepository;
-import dooya.see.user.fixture.UserSignUpFixture;
+import dooya.see.common.UserSignUpFixture;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/src/test/java/dooya/see/user/application/UserSignUpServiceTest.java
+++ b/src/test/java/dooya/see/user/application/UserSignUpServiceTest.java
@@ -5,7 +5,7 @@ import dooya.see.common.exception.ErrorCode;
 import dooya.see.user.domain.Role;
 import dooya.see.user.domain.User;
 import dooya.see.user.domain.UserRepository;
-import dooya.see.common.UserSignUpFixture;
+import dooya.see.common.UserFixture;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -41,8 +41,8 @@ public class UserSignUpServiceTest {
     @Test
     void user_signUp_success() {
         // Arrange
-        UserSignUpRequest request = UserSignUpFixture.request();
-        User testUser = UserSignUpFixture.createTestUser(request);
+        UserSignUpRequest request = UserFixture.request();
+        User testUser = UserFixture.createTestUser(request);
 
         doNothing().when(userValidator).validateDuplicateEmail(request.email());
         given(passwordEncoder.encode(request.password())).willReturn(testUser.getPassword());
@@ -70,7 +70,7 @@ public class UserSignUpServiceTest {
     @Test
     void user_signUp_fail() {
         // Arrange
-        UserSignUpRequest request = UserSignUpFixture.request();
+        UserSignUpRequest request = UserFixture.request();
         doThrow(new CustomException(ErrorCode.USER_ALREADY_EXISTS)).when(userValidator).validateDuplicateEmail(request.email());
 
         // Act && Assert

--- a/src/test/java/dooya/see/user/presentation/UserControllerTest.java
+++ b/src/test/java/dooya/see/user/presentation/UserControllerTest.java
@@ -16,7 +16,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.stream.Stream;
 
-import static dooya.see.user.fixture.UserSignUpFixture.*;
+import static dooya.see.common.UserSignUpFixture.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;

--- a/src/test/java/dooya/see/user/presentation/UserControllerTest.java
+++ b/src/test/java/dooya/see/user/presentation/UserControllerTest.java
@@ -11,7 +11,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.stream.Stream;
@@ -24,6 +26,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
+@Sql("classpath:init.sql")
 class UserControllerTest {
 
     @Autowired

--- a/src/test/java/dooya/see/user/presentation/UserControllerTest.java
+++ b/src/test/java/dooya/see/user/presentation/UserControllerTest.java
@@ -16,7 +16,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.stream.Stream;
 
-import static dooya.see.common.UserSignUpFixture.*;
+import static dooya.see.common.UserFixture.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;

--- a/src/test/resources/init.sql
+++ b/src/test/resources/init.sql
@@ -1,0 +1,1 @@
+TRUNCATE TABLE users;


### PR DESCRIPTION
## 📌 Issue

<!-- 해결하려는 이슈 번호나 주제를 명확하게 적어주세요. -->

- 관련 이슈: #16

---

## 🧐 현재 상황

<!-- 현재 발생한 문제, 개선이 필요한 사항을 간략히 설명해주세요. -->

- 로그인 API 기능, Jwt 토큰 생성

---

## 🎯 목표

<!-- 이슈를 통해 달성하고자 하는 목표를 설명해주세요. -->

- 로그인 성공시 토큰 쿠키에 저장

---

## 🛠 작업 내용

- 작업 할 내용을 입력해주세요.

- [x] 로그인 기능 구현
- [x] jwt 토큰 생성 후 쿠키에 저장
- [x] 테스트 작성

---

## 🚀 기타 사항

<!-- 리뷰어가 추가적으로 알아야 할 사항이 있다면 기재해주세요. -->

- 추가적인 내용을 작성해주세요.(참고 자료, 협업 내용)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - JWT 기반 인증 기능이 도입되어 로그인 시 토큰이 발급되고, 인증 및 인가 처리가 강화되었습니다.
  - 로그인 API가 추가되어 이메일과 비밀번호로 로그인할 수 있습니다.
  - 인증 실패 및 권한 부족 시 사용자에게 JSON 형식의 에러 메시지가 반환됩니다.

- **버그 수정**
  - 없음

- **테스트**
  - 로그인 서비스와 컨트롤러에 대한 단위 및 통합 테스트가 추가되었습니다.
  - 테스트용 사용자 및 로그인 요청 객체를 위한 픽스처가 도입되었습니다.

- **기타**
  - 일부 예외 처리 방식이 변경되었습니다(내부 서버 오류 관련 코드 및 핸들러 제거).
  - 테스트 코드에서 픽스처 클래스 경로가 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->