### PR TITLE
AuthControllerTest 테스트 추가 및 DTO 수정

### DIFF
--- a/src/main/java/dooya/see/auth/application/LoginRequest.java
+++ b/src/main/java/dooya/see/auth/application/LoginRequest.java
@@ -3,7 +3,7 @@ package dooya.see.auth.application;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 
-@Builder
+@Builder(toBuilder = true)
 public record LoginRequest(
         @NotBlank(message = "이메일은 비어 있을 수 없습니다")
         String email,

--- a/src/test/java/dooya/see/auth/presentation/AuthControllerTest.java
+++ b/src/test/java/dooya/see/auth/presentation/AuthControllerTest.java
@@ -7,6 +7,9 @@ import dooya.see.user.infrastructure.UserJpaRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -16,8 +19,12 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.util.stream.Stream;
+
 import static dooya.see.common.AuthFixture.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
@@ -53,6 +60,38 @@ public class AuthControllerTest {
         mockMvc.perform(post("/api/auth/login")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isOk());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.accessToken").exists())
+                .andExpect(result -> {
+                    String cookie = result.getResponse().getHeader("Set-Cookie");
+                    assertThat(cookie).contains("Authorization");
+                });
+    }
+
+    @DisplayName("유저 로그인 실패 테스트 - 개별 필드 유효성 검증")
+    @ParameterizedTest(name = "{index} => 필드 = {0}, 메시지 = {1}")
+    @MethodSource("invalidFieldProvider")
+    void user_login_fail_invalidField(LoginRequest request, String field, String message) throws Exception {
+        mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(false))
+                .andExpect(jsonPath("$.message").value("잘못된 요청입니다."))
+                .andExpect(jsonPath("$.validationErrors[0].field").value(field))
+                .andExpect(jsonPath("$.validationErrors[0].message").value(message));
+    }
+
+    private static Stream<Arguments> invalidFieldProvider() {
+        return Stream.of(
+                Arguments.of(
+                        request().toBuilder().email("").build(),
+                        "email", "이메일은 비어 있을 수 없습니다"
+                ),
+                Arguments.of(
+                        request().toBuilder().password("").build(),
+                        "password", "비밀번호는 비어 있을 수 없습니다"
+                )
+        );
     }
 }


### PR DESCRIPTION
## 📌 Issue

<!-- 해결하려는 이슈 번호나 주제를 명확하게 적어주세요. -->

- 관련 이슈: #16

---

## 🧐 현재 상황

<!-- 현재 발생한 문제, 개선이 필요한 사항을 간략히 설명해주세요. -->

- 예외 테스트 추가

---

## 🎯 목표

<!-- 이슈를 통해 달성하고자 하는 목표를 설명해주세요. -->

- 테스트 추가하여 더 안전한 검증

---

## 🛠 작업 내용

- 작업 할 내용을 입력해주세요.

- [x] 테스트 추가

---

## 🚀 기타 사항

<!-- 리뷰어가 추가적으로 알아야 할 사항이 있다면 기재해주세요. -->

- 추가적인 내용을 작성해주세요.(참고 자료, 협업 내용)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **테스트**
  - 로그인 성공 시 응답에 accessToken이 포함되고, Set-Cookie 헤더에 Authorization 쿠키가 있는지 검증을 추가했습니다.
  - 이메일 또는 비밀번호가 비어있는 경우 로그인 실패(400 Bad Request) 및 상세 오류 메시지를 검증하는 파라미터화 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->