### PR TITLE
토큰으로 유저 조회, 이메일 중복확인 기능 추가

### DIFF
--- a/src/main/java/dooya/see/user/application/UserQueryService.java
+++ b/src/main/java/dooya/see/user/application/UserQueryService.java
@@ -1,0 +1,7 @@
+package dooya.see.user.application;
+
+import dooya.see.user.domain.User;
+
+public interface UserQueryService {
+    User getUserFromToken(String email);
+}

--- a/src/main/java/dooya/see/user/application/UserQueryServiceImpl.java
+++ b/src/main/java/dooya/see/user/application/UserQueryServiceImpl.java
@@ -1,0 +1,17 @@
+package dooya.see.user.application;
+
+import dooya.see.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserQueryServiceImpl implements UserQueryService {
+
+    private final UserValidator userValidator;
+
+    @Override
+    public User getUserFromToken(String email) {
+        return userValidator.getUserFromToken(email);
+    }
+}

--- a/src/main/java/dooya/see/user/application/UserValidator.java
+++ b/src/main/java/dooya/see/user/application/UserValidator.java
@@ -1,5 +1,8 @@
 package dooya.see.user.application;
 
+import dooya.see.user.domain.User;
+
 public interface UserValidator {
     void validateDuplicateEmail(String email);
+    User getUserFromToken(String email);
 }

--- a/src/main/java/dooya/see/user/application/UserValidatorImpl.java
+++ b/src/main/java/dooya/see/user/application/UserValidatorImpl.java
@@ -6,7 +6,6 @@ import dooya.see.user.domain.User;
 import dooya.see.user.domain.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
-import org.springframework.stereotype.Service;
 
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/dooya/see/user/application/UserValidatorImpl.java
+++ b/src/main/java/dooya/see/user/application/UserValidatorImpl.java
@@ -20,6 +20,11 @@ public class UserValidatorImpl implements UserValidator {
                 .ifPresent(UserValidatorImpl::throwUserAlreadyExists);
     }
 
+    @Override
+    public User getUserFromToken(String email) {
+        return userRepository.findByEmail(email).orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+    }
+
     private static void throwUserAlreadyExists(User user) {
         throw new CustomException(ErrorCode.USER_ALREADY_EXISTS);
     }

--- a/src/main/java/dooya/see/user/presentation/UserController.java
+++ b/src/main/java/dooya/see/user/presentation/UserController.java
@@ -1,15 +1,15 @@
 package dooya.see.user.presentation;
 
+import dooya.see.auth.domain.LoginUser;
+import dooya.see.user.application.UserQueryService;
 import dooya.see.user.application.UserSignUpCommand;
 import dooya.see.user.application.UserSignUpService;
 import dooya.see.user.domain.User;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
 
@@ -19,6 +19,7 @@ import java.net.URI;
 public class UserController {
 
     private final UserSignUpService userSignUpService;
+    private final UserQueryService userQueryService;
 
     @PostMapping
     public ResponseEntity<UserSignUpResponse> userSignUp(@Valid @RequestBody UserSignUpRequest request) {
@@ -27,5 +28,14 @@ public class UserController {
         UserSignUpResponse response = UserDtoMapper.toResponse(user);
 
         return ResponseEntity.created(URI.create("/api/users/" + user.getId())).body(response);
+    }
+
+    @GetMapping
+    public ResponseEntity<UserSignUpResponse> getUserByToken(@AuthenticationPrincipal LoginUser loginUser) {
+        String email = loginUser.getUsername();
+        User user = userQueryService.getUserFromToken(email);
+        UserSignUpResponse response = UserDtoMapper.toResponse(user);
+
+        return ResponseEntity.ok().body(response);
     }
 }

--- a/src/main/java/dooya/see/user/presentation/UserController.java
+++ b/src/main/java/dooya/see/user/presentation/UserController.java
@@ -4,6 +4,7 @@ import dooya.see.auth.domain.LoginUser;
 import dooya.see.user.application.UserQueryService;
 import dooya.see.user.application.UserSignUpCommand;
 import dooya.see.user.application.UserSignUpService;
+import dooya.see.user.application.UserValidator;
 import dooya.see.user.domain.User;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +21,7 @@ public class UserController {
 
     private final UserSignUpService userSignUpService;
     private final UserQueryService userQueryService;
+    private final UserValidator userValidator;
 
     @PostMapping
     public ResponseEntity<UserSignUpResponse> userSignUp(@Valid @RequestBody UserSignUpRequest request) {
@@ -37,5 +39,11 @@ public class UserController {
         UserSignUpResponse response = UserDtoMapper.toResponse(user);
 
         return ResponseEntity.ok().body(response);
+    }
+
+    @GetMapping("check-email")
+    public ResponseEntity<Void> checkEmailDuplicate(@RequestParam String email) {
+        userValidator.validateDuplicateEmail(email);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/dooya/see/user/presentation/UserSignUpResponse.java
+++ b/src/main/java/dooya/see/user/presentation/UserSignUpResponse.java
@@ -1,7 +1,6 @@
 package dooya.see.user.presentation;
 
 import dooya.see.user.domain.Role;
-import dooya.see.user.domain.User;
 import lombok.Builder;
 
 import java.time.LocalDate;

--- a/src/test/java/dooya/see/user/application/UserQueryServiceTest.java
+++ b/src/test/java/dooya/see/user/application/UserQueryServiceTest.java
@@ -1,0 +1,66 @@
+package dooya.see.user.application;
+
+import dooya.see.common.exception.CustomException;
+import dooya.see.common.exception.ErrorCode;
+import dooya.see.user.domain.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static dooya.see.common.UserFixture.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+
+@ExtendWith(MockitoExtension.class)
+public class UserQueryServiceTest {
+
+    @InjectMocks
+    private UserQueryServiceImpl userQueryService;
+
+    @Mock
+    private UserValidator userValidator;
+
+    private final User testUser = testUser();
+
+    @DisplayName("토큰으로 유저 조회 성공 단위테스트")
+    @Test
+    void user_getUserFromToken_success() {
+        // Arrange
+        given(userValidator.getUserFromToken(testUser.getEmail())).willReturn(testUser);
+
+        // Act
+        User user = userQueryService.getUserFromToken(testUser.getEmail());
+
+        // Assert
+        assertAll(
+                () -> assertThat(user.getId()).isEqualTo(testUser.getId()),
+                () -> assertThat(user.getEmail()).isEqualTo(testUser.getEmail()),
+                () -> assertThat(user.getName()).isEqualTo(testUser.getName()),
+                () -> assertThat(user.getBirthDate()).isEqualTo(testUser.getBirthDate()),
+                () -> assertThat(user.getPhoneNumber()).isEqualTo(testUser.getPhoneNumber()),
+                () -> assertThat(user.getRole()).isEqualTo(testUser.getRole())
+        );
+    }
+
+    @DisplayName("토큰으로 유저 조회 실패 단위테스트 - 존재하지 않는 이메일")
+    @Test
+    void user_getUserFromToken_failNotEmail() {
+        // Arrange
+        doThrow(new CustomException(ErrorCode.USER_NOT_FOUND)).when(userValidator).getUserFromToken(testUser.getEmail());
+
+        // Act && Assert
+        assertThatCode(() -> userQueryService.getUserFromToken(testUser.getEmail()))
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining("존재하지 않는 사용자입니다.");
+
+        then(userValidator).should(times(1)).getUserFromToken(testUser.getEmail());
+    }
+}

--- a/src/test/java/dooya/see/user/presentation/UserControllerTest.java
+++ b/src/test/java/dooya/see/user/presentation/UserControllerTest.java
@@ -159,4 +159,33 @@ class UserControllerTest {
                 .andExpect(jsonPath("$.status").value(false))
                 .andExpect(jsonPath("$.message").value("존재하지 않는 사용자입니다."));
     }
+
+    @DisplayName("이메일 중복 확인 성공 테스트")
+    @Test
+    void findByEmail_user_success() throws Exception {
+        // Arrange
+        String email = "test@see.com";
+
+        // Act && Assert
+        mockMvc.perform(get("/api/users/check-email")
+                .param("email", email)
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+    }
+
+    @DisplayName("이메일로 중복 확인 실패 테스트")
+    @Test
+    void findByEmail_user_fail() throws Exception {
+        // Arrange
+        userJpaRepository.save(testUser());
+        String email = "test@see.com";
+
+        // Act && Assert
+        mockMvc.perform(get("/api/users/check-email")
+                        .param("email", email)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.status").value(false))
+                .andExpect(jsonPath("$.message").value("이미 존재하는 사용자입니다."));
+    }
 }

--- a/src/test/java/dooya/see/user/presentation/UserControllerTest.java
+++ b/src/test/java/dooya/see/user/presentation/UserControllerTest.java
@@ -1,6 +1,9 @@
 package dooya.see.user.presentation;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import dooya.see.auth.util.JwtUtil;
+import dooya.see.user.domain.User;
+import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -17,6 +20,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import java.util.stream.Stream;
 
 import static dooya.see.common.UserFixture.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -32,6 +36,9 @@ class UserControllerTest {
 
     @Autowired
     private ObjectMapper objectMapper;
+
+    @Autowired
+    private JwtUtil jwtUtil;
 
     @DisplayName("유저 회원가입 성공 테스트")
     @Test
@@ -111,5 +118,19 @@ class UserControllerTest {
                         "phoneNumber", "전화번호는 비어 있을 수 없습니다"
                 )
         );
+    }
+
+    @DisplayName("토큰으로 유저 정보 조회 성공 테스트")
+    @Test
+    void findByToken_user_success() throws Exception {
+        // Arrange
+        User testUser = testUser();
+        String testToken = jwtUtil.createAccessToken(testUser.getId(), testUser.getEmail(), testUser.getRole());
+
+        // Act & Assert
+        mockMvc.perform(get("/api/users")
+                        .cookie(new Cookie("Authorization", testToken))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
     }
 }

--- a/src/test/java/dooya/see/user/presentation/UserControllerTest.java
+++ b/src/test/java/dooya/see/user/presentation/UserControllerTest.java
@@ -3,6 +3,7 @@ package dooya.see.user.presentation;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dooya.see.auth.util.JwtUtil;
 import dooya.see.user.domain.User;
+import dooya.see.user.infrastructure.UserJpaRepository;
 import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -39,6 +40,9 @@ class UserControllerTest {
 
     @Autowired
     private JwtUtil jwtUtil;
+
+    @Autowired
+    private UserJpaRepository userJpaRepository;
 
     @DisplayName("유저 회원가입 성공 테스트")
     @Test
@@ -124,13 +128,35 @@ class UserControllerTest {
     @Test
     void findByToken_user_success() throws Exception {
         // Arrange
-        User testUser = testUser();
+        User testUser = userJpaRepository.save(testUser());
         String testToken = jwtUtil.createAccessToken(testUser.getId(), testUser.getEmail(), testUser.getRole());
 
         // Act & Assert
         mockMvc.perform(get("/api/users")
                         .cookie(new Cookie("Authorization", testToken))
                         .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(testUser.getId()))
+                .andExpect(jsonPath("$.email").value(testUser.getEmail()))
+                .andExpect(jsonPath("$.name").value(testUser.getName()))
+                .andExpect(jsonPath("$.birthDate").value(testUser.getBirthDate().toString()))
+                .andExpect(jsonPath("$.phoneNumber").value(testUser.getPhoneNumber()))
+                .andExpect(jsonPath("$.role").value(testUser.getRole().getRoleName()));
+    }
+
+    @DisplayName("토큰으로 유저 정보 조회 실패 테스트")
+    @Test
+    void findByToken_user_fail() throws Exception {
+        // Arrange
+        User testUser = userJpaRepository.save(testUser());
+        String testToken = jwtUtil.createAccessToken(testUser.getId(), "test@fail.com", testUser.getRole());
+
+        // Act & Assert
+        mockMvc.perform(get("/api/users")
+                        .cookie(new Cookie("Authorization", testToken))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.status").value(false))
+                .andExpect(jsonPath("$.message").value("존재하지 않는 사용자입니다."));
     }
 }


### PR DESCRIPTION
## 📌 Issue

<!-- 해결하려는 이슈 번호나 주제를 명확하게 적어주세요. -->

- closed #25

---

## 🧐 현재 상황

<!-- 현재 발생한 문제, 개선이 필요한 사항을 간략히 설명해주세요. -->

- 개선이 필요한 사항을 간략히 설명해주세요.

---

## 🎯 목표

<!-- 이슈를 통해 달성하고자 하는 목표를 설명해주세요. -->

- 토큰으로 유저 조회, 이메일 중복확인 기능 추가

---

## 🛠 작업 내용

- 작업 할 내용을 입력해주세요.

- [x] 토큰으로 유저 조회
- [x] 이메일 중복확인 기능

---

## 🚀 기타 사항

<!-- 리뷰어가 추가적으로 알아야 할 사항이 있다면 기재해주세요. -->

- 추가적인 내용을 작성해주세요.(참고 자료, 협업 내용)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 인증된 사용자의 정보를 조회하는 GET API가 추가되었습니다.
    - 이메일 중복 여부를 확인하는 GET API가 추가되었습니다.

- **버그 수정**
    - 이메일이 존재하지 않을 경우 404 오류를 반환하도록 개선되었습니다.
    - 이미 존재하는 이메일로 중복 확인 시 409 오류를 반환하도록 처리되었습니다.

- **테스트**
    - 사용자 정보 조회 및 이메일 중복 확인 API에 대한 단위 및 통합 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->