### PR TITLE
UserValidator -> UserQueryService로 조회 책임 이동

### DIFF
--- a/src/main/java/dooya/see/user/application/UserQueryService.java
+++ b/src/main/java/dooya/see/user/application/UserQueryService.java
@@ -3,5 +3,5 @@ package dooya.see.user.application;
 import dooya.see.user.domain.User;
 
 public interface UserQueryService {
-    User getUserFromToken(String email);
+    User getUserByEmail(String email);
 }

--- a/src/main/java/dooya/see/user/application/UserQueryServiceImpl.java
+++ b/src/main/java/dooya/see/user/application/UserQueryServiceImpl.java
@@ -1,6 +1,9 @@
 package dooya.see.user.application;
 
+import dooya.see.common.exception.CustomException;
+import dooya.see.common.exception.ErrorCode;
 import dooya.see.user.domain.User;
+import dooya.see.user.domain.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -8,10 +11,10 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class UserQueryServiceImpl implements UserQueryService {
 
-    private final UserValidator userValidator;
+    private final UserRepository userRepository;
 
     @Override
-    public User getUserFromToken(String email) {
-        return userValidator.getUserFromToken(email);
+    public User getUserByEmail(String email) {
+        return userRepository.findByEmail(email).orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
     }
 }

--- a/src/main/java/dooya/see/user/application/UserValidator.java
+++ b/src/main/java/dooya/see/user/application/UserValidator.java
@@ -1,8 +1,5 @@
 package dooya.see.user.application;
 
-import dooya.see.user.domain.User;
-
 public interface UserValidator {
     void validateDuplicateEmail(String email);
-    User getUserFromToken(String email);
 }

--- a/src/main/java/dooya/see/user/application/UserValidatorImpl.java
+++ b/src/main/java/dooya/see/user/application/UserValidatorImpl.java
@@ -19,11 +19,6 @@ public class UserValidatorImpl implements UserValidator {
                 .ifPresent(UserValidatorImpl::throwUserAlreadyExists);
     }
 
-    @Override
-    public User getUserFromToken(String email) {
-        return userRepository.findByEmail(email).orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-    }
-
     private static void throwUserAlreadyExists(User user) {
         throw new CustomException(ErrorCode.USER_ALREADY_EXISTS);
     }

--- a/src/main/java/dooya/see/user/presentation/UserController.java
+++ b/src/main/java/dooya/see/user/presentation/UserController.java
@@ -33,9 +33,9 @@ public class UserController {
     }
 
     @GetMapping
-    public ResponseEntity<UserSignUpResponse> getUserByToken(@AuthenticationPrincipal LoginUser loginUser) {
+    public ResponseEntity<UserSignUpResponse> getUserByEmail(@AuthenticationPrincipal LoginUser loginUser) {
         String email = loginUser.getUsername();
-        User user = userQueryService.getUserFromToken(email);
+        User user = userQueryService.getUserByEmail(email);
         UserSignUpResponse response = UserDtoMapper.toResponse(user);
 
         return ResponseEntity.ok().body(response);

--- a/src/test/java/dooya/see/user/application/UserQueryServiceTest.java
+++ b/src/test/java/dooya/see/user/application/UserQueryServiceTest.java
@@ -35,7 +35,7 @@ public class UserQueryServiceTest {
 
     @DisplayName("이메일로 유저 조회 성공 단위테스트")
     @Test
-    void user_getUserFromEmail_success() {
+    void user_getUserByEmail_success() {
         // Arrange
         given(userRepository.findByEmail(testUser.getEmail())).willReturn(Optional.of(testUser));
 
@@ -55,7 +55,7 @@ public class UserQueryServiceTest {
 
     @DisplayName("이메일로 유저 조회 실패 단위테스트 - 존재하지 않는 이메일")
     @Test
-    void user_getUserFromEmail_failNotEmail() {
+    void user_getUserByEmail_failNotEmail() {
         // Arrange
         doThrow(new CustomException(ErrorCode.USER_NOT_FOUND)).when(userRepository).findByEmail(testUser.getEmail());
 

--- a/src/test/java/dooya/see/user/application/UserQueryServiceTest.java
+++ b/src/test/java/dooya/see/user/application/UserQueryServiceTest.java
@@ -3,12 +3,15 @@ package dooya.see.user.application;
 import dooya.see.common.exception.CustomException;
 import dooya.see.common.exception.ErrorCode;
 import dooya.see.user.domain.User;
+import dooya.see.user.domain.UserRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
 
 import static dooya.see.common.UserFixture.*;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -26,7 +29,7 @@ public class UserQueryServiceTest {
     private UserQueryServiceImpl userQueryService;
 
     @Mock
-    private UserValidator userValidator;
+    private UserRepository userRepository;
 
     private final User testUser = testUser();
 
@@ -34,10 +37,10 @@ public class UserQueryServiceTest {
     @Test
     void user_getUserFromToken_success() {
         // Arrange
-        given(userValidator.getUserFromToken(testUser.getEmail())).willReturn(testUser);
+        given(userRepository.findByEmail(testUser.getEmail())).willReturn(Optional.of(testUser));
 
         // Act
-        User user = userQueryService.getUserFromToken(testUser.getEmail());
+        User user = userQueryService.getUserByEmail(testUser.getEmail());
 
         // Assert
         assertAll(
@@ -54,13 +57,13 @@ public class UserQueryServiceTest {
     @Test
     void user_getUserFromToken_failNotEmail() {
         // Arrange
-        doThrow(new CustomException(ErrorCode.USER_NOT_FOUND)).when(userValidator).getUserFromToken(testUser.getEmail());
+        doThrow(new CustomException(ErrorCode.USER_NOT_FOUND)).when(userRepository).findByEmail(testUser.getEmail());
 
         // Act && Assert
-        assertThatCode(() -> userQueryService.getUserFromToken(testUser.getEmail()))
+        assertThatCode(() -> userQueryService.getUserByEmail(testUser.getEmail()))
                 .isInstanceOf(CustomException.class)
                 .hasMessageContaining("존재하지 않는 사용자입니다.");
 
-        then(userValidator).should(times(1)).getUserFromToken(testUser.getEmail());
+        then(userRepository).should(times(1)).findByEmail(testUser.getEmail());
     }
 }

--- a/src/test/java/dooya/see/user/application/UserQueryServiceTest.java
+++ b/src/test/java/dooya/see/user/application/UserQueryServiceTest.java
@@ -33,9 +33,9 @@ public class UserQueryServiceTest {
 
     private final User testUser = testUser();
 
-    @DisplayName("토큰으로 유저 조회 성공 단위테스트")
+    @DisplayName("이메일로 유저 조회 성공 단위테스트")
     @Test
-    void user_getUserFromToken_success() {
+    void user_getUserFromEmail_success() {
         // Arrange
         given(userRepository.findByEmail(testUser.getEmail())).willReturn(Optional.of(testUser));
 
@@ -53,9 +53,9 @@ public class UserQueryServiceTest {
         );
     }
 
-    @DisplayName("토큰으로 유저 조회 실패 단위테스트 - 존재하지 않는 이메일")
+    @DisplayName("이메일로 유저 조회 실패 단위테스트 - 존재하지 않는 이메일")
     @Test
-    void user_getUserFromToken_failNotEmail() {
+    void user_getUserFromEmail_failNotEmail() {
         // Arrange
         doThrow(new CustomException(ErrorCode.USER_NOT_FOUND)).when(userRepository).findByEmail(testUser.getEmail());
 

--- a/src/test/java/dooya/see/user/presentation/UserControllerTest.java
+++ b/src/test/java/dooya/see/user/presentation/UserControllerTest.java
@@ -124,7 +124,7 @@ class UserControllerTest {
         );
     }
 
-    @DisplayName("토큰으로 유저 정보 조회 성공 테스트")
+    @DisplayName("토큰에 포함된 이메일로 유저 조회 성공테스트")
     @Test
     void findByToken_user_success() throws Exception {
         // Arrange
@@ -144,7 +144,7 @@ class UserControllerTest {
                 .andExpect(jsonPath("$.role").value(testUser.getRole().getRoleName()));
     }
 
-    @DisplayName("토큰으로 유저 정보 조회 실패 테스트")
+    @DisplayName("토큰에 포함된 이메일로 유저 조회 실패 테스트")
     @Test
     void findByToken_user_fail() throws Exception {
         // Arrange


### PR DESCRIPTION
## 📌 Issue

<!-- 해결하려는 이슈 번호나 주제를 명확하게 적어주세요. -->

- closed #25

---

## 🧐 현재 상황

<!-- 현재 발생한 문제, 개선이 필요한 사항을 간략히 설명해주세요. -->

- UserValidator SRP 원칙 준수하지 않음
- UserQueryService로 책임 이전하여 SRP 원칙 준수
- 메서드명 명확하지 않아 헷갈림

---

## 🎯 목표

<!-- 이슈를 통해 달성하고자 하는 목표를 설명해주세요. -->

- SRP 원칙 준수
- 메서드명 명확하게 변경

---

## 🛠 작업 내용

- 작업 할 내용을 입력해주세요.

- [x] UserValidator -> UserQueryService로 조회 책임 전가
- [x] 메서드명 수정
- [x] 테스트 수정

---

## 🚀 기타 사항

<!-- 리뷰어가 추가적으로 알아야 할 사항이 있다면 기재해주세요. -->

- 추가적인 내용을 작성해주세요.(참고 자료, 협업 내용)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - 사용자 정보를 이메일로 조회하도록 관련 기능의 명칭과 내부 동작을 일관성 있게 변경하였습니다.

- **Tests**
  - 이메일 기반 사용자 조회로 테스트 코드를 수정하였으며, 테스트 설명 문구를 보다 명확하게 업데이트하였습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->