### PR TITLE
유저 정보 수정 기능 추가

### DIFF
--- a/src/main/java/dooya/see/user/application/UserQueryServiceImpl.java
+++ b/src/main/java/dooya/see/user/application/UserQueryServiceImpl.java
@@ -6,6 +6,7 @@ import dooya.see.user.domain.User;
 import dooya.see.user.domain.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -13,6 +14,7 @@ public class UserQueryServiceImpl implements UserQueryService {
 
     private final UserRepository userRepository;
 
+    @Transactional
     @Override
     public User getUserByEmail(String email) {
         return userRepository.findByEmail(email).orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));

--- a/src/main/java/dooya/see/user/application/UserUpdateCommand.java
+++ b/src/main/java/dooya/see/user/application/UserUpdateCommand.java
@@ -1,0 +1,6 @@
+package dooya.see.user.application;
+
+public record UserUpdateCommand(
+        String nickName
+) {
+}

--- a/src/main/java/dooya/see/user/application/UserUpdateService.java
+++ b/src/main/java/dooya/see/user/application/UserUpdateService.java
@@ -1,0 +1,7 @@
+package dooya.see.user.application;
+
+import dooya.see.user.domain.User;
+
+public interface UserUpdateService {
+    User updateNickName(User user, UserUpdateCommand command);
+}

--- a/src/main/java/dooya/see/user/application/UserUpdateService.java
+++ b/src/main/java/dooya/see/user/application/UserUpdateService.java
@@ -3,5 +3,5 @@ package dooya.see.user.application;
 import dooya.see.user.domain.User;
 
 public interface UserUpdateService {
-    User updateNickName(User user, UserUpdateCommand command);
+    User updateNickName(String email, UserUpdateCommand command);
 }

--- a/src/main/java/dooya/see/user/application/UserUpdateService.java
+++ b/src/main/java/dooya/see/user/application/UserUpdateService.java
@@ -3,5 +3,5 @@ package dooya.see.user.application;
 import dooya.see.user.domain.User;
 
 public interface UserUpdateService {
-    User updateNickName(User user, UserUpdateCommand command);
+    void updateNickName(User user, UserUpdateCommand command);
 }

--- a/src/main/java/dooya/see/user/application/UserUpdateService.java
+++ b/src/main/java/dooya/see/user/application/UserUpdateService.java
@@ -3,5 +3,5 @@ package dooya.see.user.application;
 import dooya.see.user.domain.User;
 
 public interface UserUpdateService {
-    void updateNickName(User user, UserUpdateCommand command);
+    User updateNickName(User user, UserUpdateCommand command);
 }

--- a/src/main/java/dooya/see/user/application/UserUpdateServiceImpl.java
+++ b/src/main/java/dooya/see/user/application/UserUpdateServiceImpl.java
@@ -9,8 +9,7 @@ import org.springframework.stereotype.Service;
 public class UserUpdateServiceImpl implements UserUpdateService {
 
     @Override
-    public User updateNickName(User user, UserUpdateCommand command) {
+    public void updateNickName(User user, UserUpdateCommand command) {
         user.updateNickName(command.nickName());
-        return user;
     }
 }

--- a/src/main/java/dooya/see/user/application/UserUpdateServiceImpl.java
+++ b/src/main/java/dooya/see/user/application/UserUpdateServiceImpl.java
@@ -9,7 +9,8 @@ import org.springframework.stereotype.Service;
 public class UserUpdateServiceImpl implements UserUpdateService {
 
     @Override
-    public void updateNickName(User user, UserUpdateCommand command) {
+    public User updateNickName(User user, UserUpdateCommand command) {
         user.updateNickName(command.nickName());
+        return user;
     }
 }

--- a/src/main/java/dooya/see/user/application/UserUpdateServiceImpl.java
+++ b/src/main/java/dooya/see/user/application/UserUpdateServiceImpl.java
@@ -1,0 +1,16 @@
+package dooya.see.user.application;
+
+import dooya.see.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserUpdateServiceImpl implements UserUpdateService {
+
+    @Override
+    public User updateNickName(User user, UserUpdateCommand command) {
+        user.updateNickName(command.nickName());
+        return user;
+    }
+}

--- a/src/main/java/dooya/see/user/application/UserUpdateServiceImpl.java
+++ b/src/main/java/dooya/see/user/application/UserUpdateServiceImpl.java
@@ -1,16 +1,26 @@
 package dooya.see.user.application;
 
+import dooya.see.common.exception.CustomException;
+import dooya.see.common.exception.ErrorCode;
 import dooya.see.user.domain.User;
+import dooya.see.user.domain.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class UserUpdateServiceImpl implements UserUpdateService {
 
+    private final UserRepository userRepository;
+
+    @Transactional
     @Override
-    public User updateNickName(User user, UserUpdateCommand command) {
+    public User updateNickName(String email, UserUpdateCommand command) {
+        User user = userRepository.findByEmail(email)
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
         user.updateNickName(command.nickName());
+
         return user;
     }
 }

--- a/src/main/java/dooya/see/user/domain/User.java
+++ b/src/main/java/dooya/see/user/domain/User.java
@@ -38,4 +38,8 @@ public class User {
                 .role(role)
                 .build();
     }
+
+    public void updateNickName(String newNickName) {
+        this.nickName = newNickName;
+    }
 }

--- a/src/main/java/dooya/see/user/presentation/UserController.java
+++ b/src/main/java/dooya/see/user/presentation/UserController.java
@@ -51,9 +51,8 @@ public class UserController {
                                                                  @Valid @RequestBody UserUpdateRequest request) {
         String email = loginUser.getUsername();
         UserUpdateCommand command = UserDtoMapper.toUpdateCommand(request);
-        User user = userQueryService.getUserByEmail(email);
 
-        userUpdateService.updateNickName(user, command);
+        User user = userUpdateService.updateNickName(email, command);
 
         UserUpdateResponse response = UserDtoMapper.toUpdateResponse(user);
         return ResponseEntity.ok().body(response);

--- a/src/main/java/dooya/see/user/presentation/UserDtoMapper.java
+++ b/src/main/java/dooya/see/user/presentation/UserDtoMapper.java
@@ -1,11 +1,12 @@
 package dooya.see.user.presentation;
 
 import dooya.see.user.application.UserSignUpCommand;
+import dooya.see.user.application.UserUpdateCommand;
 import dooya.see.user.domain.User;
 
 public class UserDtoMapper {
 
-    public static UserSignUpCommand toCommand(UserSignUpRequest request) {
+    public static UserSignUpCommand toSignCommand(UserSignUpRequest request) {
         return new UserSignUpCommand(
                 request.email(),
                 request.name(),
@@ -13,7 +14,7 @@ public class UserDtoMapper {
                 request.nickName());
     }
 
-    public static UserSignUpResponse toResponse(User user) {
+    public static UserSignUpResponse toSignResponse(User user) {
         return new UserSignUpResponse(
                 user.getId(),
                 user.getEmail(),
@@ -21,5 +22,13 @@ public class UserDtoMapper {
                 user.getNickName(),
                 user.getRole()
         );
+    }
+
+    public static UserUpdateCommand toUpdateCommand(UserUpdateRequest request) {
+        return new UserUpdateCommand(request.nickName());
+    }
+
+    public static UserUpdateResponse toUpdateResponse(User user) {
+        return new UserUpdateResponse(user.getNickName());
     }
 }

--- a/src/main/java/dooya/see/user/presentation/UserUpdateRequest.java
+++ b/src/main/java/dooya/see/user/presentation/UserUpdateRequest.java
@@ -1,0 +1,9 @@
+package dooya.see.user.presentation;
+
+import lombok.Builder;
+
+@Builder
+public record UserUpdateRequest(
+        String nickName
+) {
+}

--- a/src/main/java/dooya/see/user/presentation/UserUpdateResponse.java
+++ b/src/main/java/dooya/see/user/presentation/UserUpdateResponse.java
@@ -1,0 +1,6 @@
+package dooya.see.user.presentation;
+
+public record UserUpdateResponse(
+        String nickName
+) {
+}

--- a/src/test/java/dooya/see/common/UserFixture.java
+++ b/src/test/java/dooya/see/common/UserFixture.java
@@ -1,6 +1,7 @@
 package dooya.see.common;
 
 import dooya.see.user.application.UserSignUpCommand;
+import dooya.see.user.application.UserUpdateCommand;
 import dooya.see.user.presentation.UserSignUpRequest;
 import dooya.see.user.domain.Role;
 import dooya.see.user.domain.User;
@@ -18,8 +19,12 @@ public class UserFixture {
         return new UserUpdateRequest("updateNickName");
     }
 
-    public static UserSignUpCommand command() {
+    public static UserSignUpCommand signUpCommand() {
         return new UserSignUpCommand("test@see.com", "testName", "testPassword", "testNickName");
+    }
+
+    public static UserUpdateCommand updateCommand() {
+        return new UserUpdateCommand("updateNickName");
     }
 
     public static User createTestUser(UserSignUpCommand command) {

--- a/src/test/java/dooya/see/common/UserFixture.java
+++ b/src/test/java/dooya/see/common/UserFixture.java
@@ -4,6 +4,7 @@ import dooya.see.user.application.UserSignUpCommand;
 import dooya.see.user.presentation.UserSignUpRequest;
 import dooya.see.user.domain.Role;
 import dooya.see.user.domain.User;
+import dooya.see.user.presentation.UserUpdateRequest;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.util.ReflectionTestUtils;
 

--- a/src/test/java/dooya/see/common/UserFixture.java
+++ b/src/test/java/dooya/see/common/UserFixture.java
@@ -9,8 +9,12 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 public class UserFixture {
 
-    public static UserSignUpRequest request() {
+    public static UserSignUpRequest signUpRequest() {
         return new UserSignUpRequest("test@see.com", "testName", "testPassword", "testNickName");
+    }
+
+    public static UserUpdateRequest updateRequest() {
+        return new UserUpdateRequest("updateNickName");
     }
 
     public static UserSignUpCommand command() {

--- a/src/test/java/dooya/see/user/application/UserSignUpServiceTest.java
+++ b/src/test/java/dooya/see/user/application/UserSignUpServiceTest.java
@@ -41,7 +41,7 @@ public class UserSignUpServiceTest {
     @Test
     void user_signUp_success() {
         // Arrange
-        UserSignUpCommand command = UserFixture.command();
+        UserSignUpCommand command = UserFixture.signUpCommand();
         User testUser = UserFixture.createTestUser(command);
 
         doNothing().when(userValidator).validateDuplicateEmail(command.email());
@@ -69,7 +69,7 @@ public class UserSignUpServiceTest {
     @Test
     void user_signUp_fail() {
         // Arrange
-        UserSignUpCommand command = UserFixture.command();
+        UserSignUpCommand command = UserFixture.signUpCommand();
         doThrow(new CustomException(ErrorCode.USER_ALREADY_EXISTS)).when(userValidator).validateDuplicateEmail(command.email());
 
         // Act && Assert

--- a/src/test/java/dooya/see/user/application/UserUpdateServiceTest.java
+++ b/src/test/java/dooya/see/user/application/UserUpdateServiceTest.java
@@ -4,17 +4,12 @@ import dooya.see.common.UserFixture;
 import dooya.see.user.domain.User;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@ExtendWith(MockitoExtension.class)
 public class UserUpdateServiceTest {
 
-    @InjectMocks
-    private UserUpdateServiceImpl userUpdateService;
+    private final UserUpdateServiceImpl userUpdateService = new UserUpdateServiceImpl();
 
     @DisplayName("유저 닉네임 업데이트 성공 테스트")
     @Test

--- a/src/test/java/dooya/see/user/application/UserUpdateServiceTest.java
+++ b/src/test/java/dooya/see/user/application/UserUpdateServiceTest.java
@@ -2,14 +2,28 @@ package dooya.see.user.application;
 
 import dooya.see.common.UserFixture;
 import dooya.see.user.domain.User;
+import dooya.see.user.domain.UserRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
 
+
+@ExtendWith(MockitoExtension.class)
 public class UserUpdateServiceTest {
 
-    private final UserUpdateServiceImpl userUpdateService = new UserUpdateServiceImpl();
+    @InjectMocks
+    private UserUpdateServiceImpl userUpdateService;
+
+    @Mock
+    private UserRepository userRepository;
 
     @DisplayName("유저 닉네임 업데이트 성공 테스트")
     @Test
@@ -18,10 +32,12 @@ public class UserUpdateServiceTest {
         User testUser = UserFixture.testUser();
         UserUpdateCommand command = UserFixture.updateCommand();
 
+        given(userRepository.findByEmail(testUser.getEmail())).willReturn(Optional.of(testUser));
+
         // Act
-        userUpdateService.updateNickName(testUser, command);
+        User user = userUpdateService.updateNickName(testUser.getEmail(), command);
 
         // Assert
-        assertThat(testUser.getNickName()).isEqualTo("updateNickName");
+        assertThat(user.getNickName()).isEqualTo(testUser.getNickName());
     }
 }

--- a/src/test/java/dooya/see/user/application/UserUpdateServiceTest.java
+++ b/src/test/java/dooya/see/user/application/UserUpdateServiceTest.java
@@ -1,0 +1,32 @@
+package dooya.see.user.application;
+
+import dooya.see.common.UserFixture;
+import dooya.see.user.domain.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+public class UserUpdateServiceTest {
+
+    @InjectMocks
+    private UserUpdateServiceImpl userUpdateService;
+
+    @DisplayName("유저 닉네임 업데이트 성공 테스트")
+    @Test
+    void user_nickNameUpdate_success() {
+        // Arrange
+        User testUser = UserFixture.testUser();
+        UserUpdateCommand command = UserFixture.updateCommand();
+
+        // Act
+        userUpdateService.updateNickName(testUser, command);
+
+        // Assert
+        assertThat(testUser.getNickName()).isEqualTo("updateNickName");
+    }
+}

--- a/src/test/java/dooya/see/user/presentation/UserControllerTest.java
+++ b/src/test/java/dooya/see/user/presentation/UserControllerTest.java
@@ -184,7 +184,7 @@ class UserControllerTest {
 
     @DisplayName("유저 정보 수정 성공 테스트")
     @Test
-    void userInfo_put_success() throws Exception {
+    void userNickName_update_success() throws Exception {
         // Arrange
         User testUser = userJpaRepository.save(testUser());
         UserUpdateRequest request = updateRequest();
@@ -195,6 +195,25 @@ class UserControllerTest {
                         .cookie(new Cookie("Authorization", testToken))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isOk());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.nickName").value(request.nickName()));
+    }
+
+    @DisplayName("유저 정보 수정 실패 테스트")
+    @Test
+    void userNickName_update_fail() throws Exception {
+        // Arrange
+        User testUser = userJpaRepository.save(testUser());
+        UserUpdateRequest request = updateRequest();
+        String testToken = jwtUtil.createAccessToken(testUser.getId(), "test@fail.com", testUser.getRole());
+
+        // Act & Assert
+        mockMvc.perform(put("/api/users")
+                        .cookie(new Cookie("Authorization", testToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.status").value(false))
+                .andExpect(jsonPath("$.message").value("존재하지 않는 사용자입니다."));
     }
 }

--- a/src/test/java/dooya/see/user/presentation/UserControllerTest.java
+++ b/src/test/java/dooya/see/user/presentation/UserControllerTest.java
@@ -23,6 +23,7 @@ import java.util.stream.Stream;
 import static dooya.see.common.UserFixture.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -47,7 +48,7 @@ class UserControllerTest {
     @DisplayName("유저 회원가입 성공 테스트")
     @Test
     void user_signUp_success() throws Exception {
-        UserSignUpRequest request = request();
+        UserSignUpRequest request = signUpRequest();
 
         mockMvc.perform(post("/api/users")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -77,7 +78,7 @@ class UserControllerTest {
     @DisplayName("유저 회원가입 실패 테스트 - 모든 필드가 공란일때")
     @Test
     void user_signUp_fail_allFieldsInvalid() throws Exception {
-        UserSignUpRequest request = request().toBuilder()
+        UserSignUpRequest request = signUpRequest().toBuilder()
                 .email("")
                 .name("")
                 .password("")
@@ -99,19 +100,19 @@ class UserControllerTest {
     private static Stream<Arguments> invalidFieldProvider() {
         return Stream.of(
                 Arguments.of(
-                        request().toBuilder().email("").build(),
+                        signUpRequest().toBuilder().email("").build(),
                         "email", "이메일은 비어 있을 수 없습니다"
                 ),
                 Arguments.of(
-                        request().toBuilder().name("").build(),
+                        signUpRequest().toBuilder().name("").build(),
                         "name", "이름은 비어 있을 수 없습니다"
                 ),
                 Arguments.of(
-                        request().toBuilder().password("").build(),
+                        signUpRequest().toBuilder().password("").build(),
                         "password", "비밀번호는 비어 있을 수 없습니다"
                 ),
                 Arguments.of(
-                        request().toBuilder().nickName("").build(),
+                        signUpRequest().toBuilder().nickName("").build(),
                         "nickName", "닉네임은 비어 있을 수 없습니다"
                 )
         );
@@ -179,5 +180,21 @@ class UserControllerTest {
                 .andExpect(status().isConflict())
                 .andExpect(jsonPath("$.status").value(false))
                 .andExpect(jsonPath("$.message").value("이미 존재하는 사용자입니다."));
+    }
+
+    @DisplayName("유저 정보 수정 성공 테스트")
+    @Test
+    void userInfo_put_success() throws Exception {
+        // Arrange
+        User testUser = userJpaRepository.save(testUser());
+        UserUpdateRequest request = updateRequest();
+        String testToken = jwtUtil.createAccessToken(testUser.getId(), testUser.getEmail(), testUser.getRole());
+
+        // Act && Assert
+        mockMvc.perform(put("/api/users")
+                        .cookie(new Cookie("Authorization", testToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk());
     }
 }

--- a/src/test/java/dooya/see/user/presentation/UserDtoMapperTest.java
+++ b/src/test/java/dooya/see/user/presentation/UserDtoMapperTest.java
@@ -1,6 +1,7 @@
 package dooya.see.user.presentation;
 
 import dooya.see.user.application.UserSignUpCommand;
+import dooya.see.user.application.UserUpdateCommand;
 import dooya.see.user.domain.User;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -19,7 +20,7 @@ public class UserDtoMapperTest {
         UserSignUpRequest request = signUpRequest();
 
         // Act
-        UserSignUpCommand command = toCommand(request);
+        UserSignUpCommand command = toSignCommand(request);
 
         // Assert
         assertAll(
@@ -37,7 +38,7 @@ public class UserDtoMapperTest {
         User user = testUser();
 
         // Act
-        UserSignUpResponse response = toResponse(user);
+        UserSignUpResponse response = toSignResponse(user);
 
         // Assert
         assertAll(
@@ -47,5 +48,31 @@ public class UserDtoMapperTest {
                 () -> assertThat(response.nickName()).isEqualTo(user.getNickName()),
                 () -> assertThat(response.role()).isEqualTo(user.getRole())
         );
+    }
+
+    @DisplayName("UserUpdateRequest를 UserUpdateCommand로 정상 변환한다")
+    @Test
+    void convert_UserUpdateRequest_to_UserUpdateCommand() {
+        // Arrange
+        UserUpdateRequest request = updateRequest();
+
+        // Act
+        UserUpdateCommand command = toUpdateCommand(request);
+
+        // Assert
+        assertThat(request.nickName()).isEqualTo(command.nickName());
+    }
+
+    @DisplayName("User를 UserUpdateResponse로 정상 변환한다")
+    @Test
+    void convert_User_to_UserUpdateResponse() {
+        // Arrange
+        User user = testUser();
+
+        // Act
+        UserUpdateResponse response = toUpdateResponse(user);
+
+        // Assert
+        assertThat(response.nickName()).isEqualTo(user.getNickName()); 
     }
 }

--- a/src/test/java/dooya/see/user/presentation/UserDtoMapperTest.java
+++ b/src/test/java/dooya/see/user/presentation/UserDtoMapperTest.java
@@ -16,7 +16,7 @@ public class UserDtoMapperTest {
     @Test
     void convert_UserSignRequest_to_UserSignCommand() {
         // Arrange
-        UserSignUpRequest request = request();
+        UserSignUpRequest request = signUpRequest();
 
         // Act
         UserSignUpCommand command = toCommand(request);


### PR DESCRIPTION
## 📌 Issue

<!-- 해결하려는 이슈 번호나 주제를 명확하게 적어주세요. -->

- closed #28 

---

## 🧐 현재 상황

<!-- 현재 발생한 문제, 개선이 필요한 사항을 간략히 설명해주세요. -->

- 유저 닉네임 업데이트 기능 

---

## 🎯 목표

<!-- 이슈를 통해 달성하고자 하는 목표를 설명해주세요. -->

- 유저는 닉네임을 변경할수 있음

---

## 🛠 작업 내용

- 작업 할 내용을 입력해주세요.

- [x] 웹 DTO, 서비스 DTO 생성
- [x] Mapper 클래스에 변환 메서드 작성
- [x] Controller 구현
- [x] Service 구현
- [x] 테스트 작성

---

## 🚀 기타 사항

<!-- 리뷰어가 추가적으로 알아야 할 사항이 있다면 기재해주세요. -->

- 추가적인 내용을 작성해주세요.(참고 자료, 협업 내용)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **신규 기능**
    - 사용자의 닉네임을 수정할 수 있는 API(HTTP PUT /api/users) 엔드포인트가 추가되었습니다.

- **리팩터링**
    - DTO 매핑 메서드 네이밍이 명확하게 변경되었습니다.

- **테스트**
    - 닉네임 수정 성공 및 실패 케이스에 대한 컨트롤러 테스트가 추가되었습니다.
    - 닉네임 수정 서비스 및 DTO 매핑에 대한 단위 테스트가 추가되었습니다.
    - 기존 회원가입 관련 테스트 메서드 네이밍이 명확하게 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->