### PR TITLE
Application 계층에서 도메인 객체 말고 DTO를 반환하게 변경

### DIFF
--- a/src/main/java/dooya/see/user/application/UserApplicationMapper.java
+++ b/src/main/java/dooya/see/user/application/UserApplicationMapper.java
@@ -4,7 +4,7 @@ import dooya.see.user.domain.Role;
 import dooya.see.user.domain.User;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
-public class UserCommandMapper {
+public class UserApplicationMapper {
 
     public static User toEntity(UserSignUpCommand command, PasswordEncoder passwordEncoder) {
         return User.signUpUser(
@@ -13,6 +13,16 @@ public class UserCommandMapper {
                 passwordEncoder.encode(command.password()),
                 command.nickName(),
                 Role.of("USER")
+        );
+    }
+
+    public static UserResult toResult(User user) {
+        return new UserResult(
+                user.getId(),
+                user.getEmail(),
+                user.getName(),
+                user.getNickName(),
+                user.getRole()
         );
     }
 }

--- a/src/main/java/dooya/see/user/application/UserQueryService.java
+++ b/src/main/java/dooya/see/user/application/UserQueryService.java
@@ -1,7 +1,5 @@
 package dooya.see.user.application;
 
-import dooya.see.user.domain.User;
-
 public interface UserQueryService {
-    User getUserByEmail(String email);
+    UserResult getUserByEmail(String email);
 }

--- a/src/main/java/dooya/see/user/application/UserQueryServiceImpl.java
+++ b/src/main/java/dooya/see/user/application/UserQueryServiceImpl.java
@@ -16,7 +16,9 @@ public class UserQueryServiceImpl implements UserQueryService {
 
     @Transactional
     @Override
-    public User getUserByEmail(String email) {
-        return userRepository.findByEmail(email).orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+    public UserResult getUserByEmail(String email) {
+        User user = userRepository.findByEmail(email).orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        return UserApplicationMapper.toResult(user);
     }
 }

--- a/src/main/java/dooya/see/user/application/UserResult.java
+++ b/src/main/java/dooya/see/user/application/UserResult.java
@@ -1,10 +1,12 @@
 package dooya.see.user.application;
 
+import dooya.see.user.domain.Role;
+
 public record UserResult(
         Long id,
         String email,
         String name,
         String nickName,
-        dooya.see.user.domain.Role role
+        Role role
 ) {
 }

--- a/src/main/java/dooya/see/user/application/UserResult.java
+++ b/src/main/java/dooya/see/user/application/UserResult.java
@@ -1,0 +1,10 @@
+package dooya.see.user.application;
+
+public record UserResult(
+        Long id,
+        String email,
+        String name,
+        String nickName,
+        dooya.see.user.domain.Role role
+) {
+}

--- a/src/main/java/dooya/see/user/application/UserSignUpService.java
+++ b/src/main/java/dooya/see/user/application/UserSignUpService.java
@@ -1,7 +1,5 @@
 package dooya.see.user.application;
 
-import dooya.see.user.domain.User;
-
 public interface UserSignUpService {
-    User userSignUp(UserSignUpCommand command);
+    UserResult userSignUp(UserSignUpCommand command);
 }

--- a/src/main/java/dooya/see/user/application/UserSignUpServiceImpl.java
+++ b/src/main/java/dooya/see/user/application/UserSignUpServiceImpl.java
@@ -17,10 +17,11 @@ public class UserSignUpServiceImpl implements UserSignUpService {
 
     @Transactional
     @Override
-    public User userSignUp(UserSignUpCommand command) {
+    public UserResult userSignUp(UserSignUpCommand command) {
         userValidator.validateDuplicateEmail(command.email());
-        User user = UserCommandMapper.toEntity(command, passwordEncoder);
+        User user = UserApplicationMapper.toEntity(command, passwordEncoder);
+        userRepository.save(user);
 
-        return userRepository.save(user);
+        return UserApplicationMapper.toResult(user);
     }
 }

--- a/src/main/java/dooya/see/user/application/UserUpdateService.java
+++ b/src/main/java/dooya/see/user/application/UserUpdateService.java
@@ -1,7 +1,5 @@
 package dooya.see.user.application;
 
-import dooya.see.user.domain.User;
-
 public interface UserUpdateService {
-    User updateNickName(String email, UserUpdateCommand command);
+    UserResult updateNickName(String email, UserUpdateCommand command);
 }

--- a/src/main/java/dooya/see/user/application/UserUpdateServiceImpl.java
+++ b/src/main/java/dooya/see/user/application/UserUpdateServiceImpl.java
@@ -8,6 +8,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import static dooya.see.user.application.UserApplicationMapper.*;
+
 @Service
 @RequiredArgsConstructor
 public class UserUpdateServiceImpl implements UserUpdateService {
@@ -16,11 +18,11 @@ public class UserUpdateServiceImpl implements UserUpdateService {
 
     @Transactional
     @Override
-    public User updateNickName(String email, UserUpdateCommand command) {
+    public UserResult updateNickName(String email, UserUpdateCommand command) {
         User user = userRepository.findByEmail(email)
                         .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
         user.updateNickName(command.nickName());
 
-        return user;
+        return toResult(user);
     }
 }

--- a/src/main/java/dooya/see/user/presentation/UserController.java
+++ b/src/main/java/dooya/see/user/presentation/UserController.java
@@ -2,7 +2,6 @@ package dooya.see.user.presentation;
 
 import dooya.see.auth.domain.LoginUser;
 import dooya.see.user.application.*;
-import dooya.see.user.domain.User;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -10,6 +9,8 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
+
+import static dooya.see.user.presentation.UserPresentationMapper.*;
 
 @RestController
 @RequestMapping("/api/users")
@@ -23,20 +24,18 @@ public class UserController {
 
     @PostMapping
     public ResponseEntity<UserSignUpResponse> userSignUp(@Valid @RequestBody UserSignUpRequest request) {
-        UserSignUpCommand command = UserDtoMapper.toSignCommand(request);
-        User user = userSignUpService.userSignUp(command);
+        UserSignUpCommand command = toSignCommand(request);
+        UserResult result = userSignUpService.userSignUp(command);
 
-        UserSignUpResponse response = UserDtoMapper.toSignResponse(user);
-        return ResponseEntity.created(URI.create("/api/users/" + user.getId())).body(response);
+        return ResponseEntity.created(URI.create("/api/users/" + result.id())).body(toSignResponse(result));
     }
 
     @GetMapping
     public ResponseEntity<UserSignUpResponse> getUserByEmail(@AuthenticationPrincipal LoginUser loginUser) {
         String email = loginUser.getUsername();
-        User user = userQueryService.getUserByEmail(email);
+        UserResult result = userQueryService.getUserByEmail(email);
 
-        UserSignUpResponse response = UserDtoMapper.toSignResponse(user);
-        return ResponseEntity.ok().body(response);
+        return ResponseEntity.ok().body(toSignResponse(result));
     }
 
     @GetMapping("check-email")
@@ -50,11 +49,9 @@ public class UserController {
     public ResponseEntity<UserUpdateResponse> updateUserNickName(@AuthenticationPrincipal LoginUser loginUser,
                                                                  @Valid @RequestBody UserUpdateRequest request) {
         String email = loginUser.getUsername();
-        UserUpdateCommand command = UserDtoMapper.toUpdateCommand(request);
+        UserUpdateCommand command = toUpdateCommand(request);
+        UserResult result = userUpdateService.updateNickName(email, command);
 
-        User user = userUpdateService.updateNickName(email, command);
-
-        UserUpdateResponse response = UserDtoMapper.toUpdateResponse(user);
-        return ResponseEntity.ok().body(response);
+        return ResponseEntity.ok().body(toUpdateResponse(result));
     }
 }

--- a/src/main/java/dooya/see/user/presentation/UserPresentationMapper.java
+++ b/src/main/java/dooya/see/user/presentation/UserPresentationMapper.java
@@ -1,10 +1,10 @@
 package dooya.see.user.presentation;
 
+import dooya.see.user.application.UserResult;
 import dooya.see.user.application.UserSignUpCommand;
 import dooya.see.user.application.UserUpdateCommand;
-import dooya.see.user.domain.User;
 
-public class UserDtoMapper {
+public class UserPresentationMapper {
 
     public static UserSignUpCommand toSignCommand(UserSignUpRequest request) {
         return new UserSignUpCommand(
@@ -14,13 +14,13 @@ public class UserDtoMapper {
                 request.nickName());
     }
 
-    public static UserSignUpResponse toSignResponse(User user) {
+    public static UserSignUpResponse toSignResponse(UserResult userResult) {
         return new UserSignUpResponse(
-                user.getId(),
-                user.getEmail(),
-                user.getName(),
-                user.getNickName(),
-                user.getRole()
+                userResult.id(),
+                userResult.email(),
+                userResult.name(),
+                userResult.nickName(),
+                userResult.role()
         );
     }
 
@@ -28,7 +28,7 @@ public class UserDtoMapper {
         return new UserUpdateCommand(request.nickName());
     }
 
-    public static UserUpdateResponse toUpdateResponse(User user) {
-        return new UserUpdateResponse(user.getNickName());
+    public static UserUpdateResponse toUpdateResponse(UserResult userResult) {
+        return new UserUpdateResponse(userResult.nickName());
     }
 }

--- a/src/test/java/dooya/see/common/UserFixture.java
+++ b/src/test/java/dooya/see/common/UserFixture.java
@@ -1,5 +1,6 @@
 package dooya.see.common;
 
+import dooya.see.user.application.UserResult;
 import dooya.see.user.application.UserSignUpCommand;
 import dooya.see.user.application.UserUpdateCommand;
 import dooya.see.user.presentation.UserSignUpRequest;
@@ -47,6 +48,10 @@ public class UserFixture {
                 .nickName("testNickName")
                 .role(Role.of("USER"))
                 .build();
+    }
+
+    public static UserResult testUserResult() {
+        return new UserResult(1L, "test@see.com", "testName", "testNickName", Role.of("USER"));
     }
 
     public static User mockUser(PasswordEncoder passwordEncoder) {

--- a/src/test/java/dooya/see/user/application/UserQueryServiceTest.java
+++ b/src/test/java/dooya/see/user/application/UserQueryServiceTest.java
@@ -40,15 +40,15 @@ public class UserQueryServiceTest {
         given(userRepository.findByEmail(testUser.getEmail())).willReturn(Optional.of(testUser));
 
         // Act
-        User user = userQueryService.getUserByEmail(testUser.getEmail());
+        UserResult result = userQueryService.getUserByEmail(testUser.getEmail());
 
         // Assert
         assertAll(
-                () -> assertThat(user.getId()).isEqualTo(testUser.getId()),
-                () -> assertThat(user.getEmail()).isEqualTo(testUser.getEmail()),
-                () -> assertThat(user.getName()).isEqualTo(testUser.getName()),
-                () -> assertThat(user.getNickName()).isEqualTo(testUser.getNickName()),
-                () -> assertThat(user.getRole()).isEqualTo(testUser.getRole())
+                () -> assertThat(result.id()).isEqualTo(testUser.getId()),
+                () -> assertThat(result.email()).isEqualTo(testUser.getEmail()),
+                () -> assertThat(result.name()).isEqualTo(testUser.getName()),
+                () -> assertThat(result.nickName()).isEqualTo(testUser.getNickName()),
+                () -> assertThat(result.role()).isEqualTo(testUser.getRole())
         );
     }
 

--- a/src/test/java/dooya/see/user/application/UserSignUpServiceTest.java
+++ b/src/test/java/dooya/see/user/application/UserSignUpServiceTest.java
@@ -49,16 +49,15 @@ public class UserSignUpServiceTest {
         given(userRepository.save(any(User.class))).willReturn(testUser);
 
         // Act
-        User user = userSignUpService.userSignUp(command);
+        UserResult result = userSignUpService.userSignUp(command);
 
         // Assert
         assertAll(
-                () -> assertThat(user).isNotNull(),
-                () -> assertThat(user.getId()).isNotNull(),
-                () -> assertThat(user.getEmail()).isEqualTo(command.email()),
-                () -> assertThat(user.getName()).isEqualTo(command.name()),
-                () -> assertThat(user.getNickName()).isEqualTo(command.nickName()),
-                () -> assertThat(user.getRole()).isEqualTo(Role.USER)
+                () -> assertThat(result).isNotNull(),
+                () -> assertThat(result.email()).isEqualTo(command.email()),
+                () -> assertThat(result.name()).isEqualTo(command.name()),
+                () -> assertThat(result.nickName()).isEqualTo(command.nickName()),
+                () -> assertThat(result.role()).isEqualTo(Role.USER)
         );
 
         then(userValidator).should(times(1)).validateDuplicateEmail(command.email());

--- a/src/test/java/dooya/see/user/application/UserUpdateServiceTest.java
+++ b/src/test/java/dooya/see/user/application/UserUpdateServiceTest.java
@@ -35,9 +35,9 @@ public class UserUpdateServiceTest {
         given(userRepository.findByEmail(testUser.getEmail())).willReturn(Optional.of(testUser));
 
         // Act
-        User user = userUpdateService.updateNickName(testUser.getEmail(), command);
+        UserResult result = userUpdateService.updateNickName(testUser.getEmail(), command);
 
         // Assert
-        assertThat(user.getNickName()).isEqualTo(testUser.getNickName());
+        assertThat(result.nickName()).isEqualTo(testUser.getNickName());
     }
 }

--- a/src/test/java/dooya/see/user/presentation/UserPresentationMapperTest.java
+++ b/src/test/java/dooya/see/user/presentation/UserPresentationMapperTest.java
@@ -1,17 +1,17 @@
 package dooya.see.user.presentation;
 
+import dooya.see.user.application.UserResult;
 import dooya.see.user.application.UserSignUpCommand;
 import dooya.see.user.application.UserUpdateCommand;
-import dooya.see.user.domain.User;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static dooya.see.common.UserFixture.*;
-import static dooya.see.user.presentation.UserDtoMapper.*;
+import static dooya.see.user.presentation.UserPresentationMapper.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-public class UserDtoMapperTest {
+public class UserPresentationMapperTest {
 
     @DisplayName("UserSignUpRequest를 UserSignUpCommand로 정상 변환한다")
     @Test
@@ -35,18 +35,18 @@ public class UserDtoMapperTest {
     @Test
     void convert_User_to_UserSignResponse() {
         // Arrange
-        User user = testUser();
+        UserResult result = testUserResult();
 
         // Act
-        UserSignUpResponse response = toSignResponse(user);
+        UserSignUpResponse response = toSignResponse(result);
 
         // Assert
         assertAll(
-                () -> assertThat(response.id()).isEqualTo(user.getId()),
-                () -> assertThat(response.email()).isEqualTo(user.getEmail()),
-                () -> assertThat(response.name()).isEqualTo(user.getName()),
-                () -> assertThat(response.nickName()).isEqualTo(user.getNickName()),
-                () -> assertThat(response.role()).isEqualTo(user.getRole())
+                () -> assertThat(response.id()).isEqualTo(result.id()),
+                () -> assertThat(response.email()).isEqualTo(result.email()),
+                () -> assertThat(response.name()).isEqualTo(result.name()),
+                () -> assertThat(response.nickName()).isEqualTo(result.nickName()),
+                () -> assertThat(response.role()).isEqualTo(result.role())
         );
     }
 
@@ -67,12 +67,12 @@ public class UserDtoMapperTest {
     @Test
     void convert_User_to_UserUpdateResponse() {
         // Arrange
-        User user = testUser();
+        UserResult result = testUserResult();
 
         // Act
-        UserUpdateResponse response = toUpdateResponse(user);
+        UserUpdateResponse response = toUpdateResponse(result);
 
         // Assert
-        assertThat(response.nickName()).isEqualTo(user.getNickName()); 
+        assertThat(response.nickName()).isEqualTo(result.nickName());
     }
 }


### PR DESCRIPTION
## 📌 Issue

<!-- 해결하려는 이슈 번호나 주제를 명확하게 적어주세요. -->

- closed #36

---

## 🧐 현재 상황

<!-- 현재 발생한 문제, 개선이 필요한 사항을 간략히 설명해주세요. -->

- Controller에서 domain을 의존하고 있는 상황 발생

---

## 🎯 목표

<!-- 이슈를 통해 달성하고자 하는 목표를 설명해주세요. -->

- 각 계층의 역할을 분명히 하고 의존성이 생기지 않도록 수정

---

## 🛠 작업 내용

- 작업 할 내용을 입력해주세요.

- [x] 코드 수정
- [x] 테스트 수정

---

## 🚀 기타 사항

<!-- 리뷰어가 추가적으로 알아야 할 사항이 있다면 기재해주세요. -->

- 추가적인 내용을 작성해주세요.(참고 자료, 협업 내용)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
	- 사용자 정보를 담는 새로운 DTO(UserResult)가 도입되어, 서비스와 컨트롤러에서 사용자 결과를 일관되게 반환합니다.

- **리팩터링**
	- 서비스 및 매퍼 클래스, 테스트 등에서 기존 User 엔티티 대신 UserResult DTO를 사용하도록 전체적으로 구조가 개선되었습니다.
	- 일부 클래스와 테스트의 명칭이 변경되었습니다.

- **테스트**
	- UserResult를 반영하여 테스트 코드가 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->