### PR TITLE
관리자용 회원 목록 조회 기능 추가

### DIFF
--- a/src/main/java/dooya/see/admin/presentation/AdminController.java
+++ b/src/main/java/dooya/see/admin/presentation/AdminController.java
@@ -1,0 +1,28 @@
+package dooya.see.admin.presentation;
+
+import dooya.see.user.application.dto.UserResult;
+import dooya.see.user.application.service.UserQueryService;
+import dooya.see.user.presentation.dto.UserPresentationMapper;
+import dooya.see.user.presentation.dto.UserResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/admin")
+@RequiredArgsConstructor
+public class AdminController {
+
+    private final UserQueryService userQueryService;
+
+    @GetMapping
+    public ResponseEntity<List<UserResponse>> getUsers() {
+        List<UserResult> users = userQueryService.getUsers();
+
+        return ResponseEntity.ok(UserPresentationMapper.toResponses(users));
+    }
+}

--- a/src/main/java/dooya/see/auth/config/SecurityConfig.java
+++ b/src/main/java/dooya/see/auth/config/SecurityConfig.java
@@ -47,7 +47,7 @@ public class SecurityConfig {
         http.authorizeHttpRequests((auth) -> auth
                 .requestMatchers("/api/users/**").permitAll()
                 .requestMatchers("/api/auth/**").permitAll()
-                .requestMatchers("/api/admin").hasAnyAuthority(Role.ADMIN.getRoleName())
+                .requestMatchers("/api/admin").hasAnyAuthority(Role.ADMIN.getRoleSecurity())
                 .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html", "/webjars/**").permitAll()
                 .anyRequest().authenticated());
 

--- a/src/main/java/dooya/see/auth/config/SecurityConfig.java
+++ b/src/main/java/dooya/see/auth/config/SecurityConfig.java
@@ -5,6 +5,7 @@ import dooya.see.auth.exception.CustomAccessDeniedHandler;
 import dooya.see.auth.exception.CustomAuthenticationEntryPoint;
 import dooya.see.auth.filter.JwtAuthFilter;
 import dooya.see.auth.util.JwtUtil;
+import dooya.see.user.domain.Role;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -46,6 +47,7 @@ public class SecurityConfig {
         http.authorizeHttpRequests((auth) -> auth
                 .requestMatchers("/api/users/**").permitAll()
                 .requestMatchers("/api/auth/**").permitAll()
+                .requestMatchers("/api/admin").hasAnyAuthority(Role.ADMIN.getRoleName())
                 .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html", "/webjars/**").permitAll()
                 .anyRequest().authenticated());
 

--- a/src/main/java/dooya/see/user/application/dto/UserApplicationMapper.java
+++ b/src/main/java/dooya/see/user/application/dto/UserApplicationMapper.java
@@ -4,6 +4,9 @@ import dooya.see.user.domain.Role;
 import dooya.see.user.domain.User;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 /**
  * {@code UserApplicationMapper} 클래스는 애플리케이션 계층에서
  * 사용자 관련 커맨드 객체와 도메인 엔티티, 결과 객체 간의 변환을 담당합니다.
@@ -40,5 +43,9 @@ public class UserApplicationMapper {
                 user.getNickName(),
                 user.getRole()
         );
+    }
+
+    public static List<UserResult> toResults(List<User> users) {
+        return users.stream().map(UserApplicationMapper::toResult).collect(Collectors.toList());
     }
 }

--- a/src/main/java/dooya/see/user/application/service/UserQueryService.java
+++ b/src/main/java/dooya/see/user/application/service/UserQueryService.java
@@ -2,6 +2,8 @@ package dooya.see.user.application.service;
 
 import dooya.see.user.application.dto.UserResult;
 
+import java.util.List;
+
 /**
  * {@code UserQueryService} 인터페이스는 사용자 조회와 관련된
  * 애플리케이션 계층의 서비스 계약을 정의합니다.
@@ -23,4 +25,11 @@ public interface UserQueryService {
      * @throws IllegalArgumentException 조회 대상이 없을 경우 발생 가능
      */
     UserResult getUserByEmail(String email);
+
+    /**
+     * 모든 사용자를 조회합니다.
+     *
+     * @return 조회된 사용자 정보를 닮은 {@link UserResult} 리스트
+     */
+    List<UserResult> getUsers();
 }

--- a/src/main/java/dooya/see/user/application/service/impl/UserQueryServiceImpl.java
+++ b/src/main/java/dooya/see/user/application/service/impl/UserQueryServiceImpl.java
@@ -5,11 +5,14 @@ import dooya.see.common.exception.ErrorCode;
 import dooya.see.user.application.dto.UserApplicationMapper;
 import dooya.see.user.application.dto.UserResult;
 import dooya.see.user.application.service.UserQueryService;
+import dooya.see.user.domain.Role;
 import dooya.see.user.domain.User;
 import dooya.see.user.domain.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -23,5 +26,13 @@ public class UserQueryServiceImpl implements UserQueryService {
         User user = userRepository.findByEmail(email).orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         return UserApplicationMapper.toResult(user);
+    }
+
+    @Transactional
+    @Override
+    public List<UserResult> getUsers() {
+        List<User> users = userRepository.findByRole(Role.USER);
+
+        return UserApplicationMapper.toResults(users);
     }
 }

--- a/src/main/java/dooya/see/user/domain/UserRepository.java
+++ b/src/main/java/dooya/see/user/domain/UserRepository.java
@@ -1,5 +1,6 @@
 package dooya.see.user.domain;
 
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -17,5 +18,6 @@ import java.util.Optional;
 public interface UserRepository {
     Optional<User> findById(Long id);
     Optional<User> findByEmail(String email);
+    List<User> findByRole(Role role);
     User save(User user);
 }

--- a/src/main/java/dooya/see/user/infrastructure/UserJpaRepository.java
+++ b/src/main/java/dooya/see/user/infrastructure/UserJpaRepository.java
@@ -1,10 +1,13 @@
 package dooya.see.user.infrastructure;
 
+import dooya.see.user.domain.Role;
 import dooya.see.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UserJpaRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
+    List<User> findByRole(Role role);
 }

--- a/src/main/java/dooya/see/user/infrastructure/UserRepositoryImpl.java
+++ b/src/main/java/dooya/see/user/infrastructure/UserRepositoryImpl.java
@@ -1,11 +1,13 @@
 package dooya.see.user.infrastructure;
 
+import dooya.see.user.domain.Role;
 import dooya.see.user.domain.User;
 import dooya.see.user.domain.UserRepository;
 import lombok.Builder;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -23,6 +25,11 @@ public class UserRepositoryImpl implements UserRepository {
     @Override
     public Optional<User> findByEmail(String email) {
         return userJpaRepository.findByEmail(email);
+    }
+
+    @Override
+    public List<User> findByRole(Role role) {
+        return userJpaRepository.findByRole(role);
     }
 
     @Override

--- a/src/main/java/dooya/see/user/presentation/dto/UserPresentationMapper.java
+++ b/src/main/java/dooya/see/user/presentation/dto/UserPresentationMapper.java
@@ -2,6 +2,8 @@ package dooya.see.user.presentation.dto;
 
 import dooya.see.user.application.dto.*;
 
+import java.util.List;
+
 /**
  * {@code UserPresentationMapper} 클래스는
  * 프레젠테이션 계층에서 요청(Request) 및 응답(Response) 객체와
@@ -55,5 +57,21 @@ public class UserPresentationMapper {
 
     public static PasswordUpdateResponse toPasswordUpdateResponse(PasswordUpdateResult result) {
         return new PasswordUpdateResponse(result.message());
+    }
+
+    public static UserResponse toResponse(UserResult result) {
+        return new UserResponse(
+                result.id(),
+                result.email(),
+                result.name(),
+                result.nickName(),
+                result.role()
+        );
+    }
+
+    public static List<UserResponse> toResponses(List<UserResult> results) {
+        return results.stream()
+                .map(UserPresentationMapper::toResponse)
+                .toList();
     }
 }

--- a/src/main/java/dooya/see/user/presentation/dto/UserResponse.java
+++ b/src/main/java/dooya/see/user/presentation/dto/UserResponse.java
@@ -1,0 +1,22 @@
+package dooya.see.user.presentation.dto;
+
+import dooya.see.user.domain.Role;
+
+/**
+ * {@code UserResponse} 클래스는
+ * 사용자 조회후 클라이언트에 반환되는 응답 데이터 객체입니다.
+ *
+ * <p>사용자의 ID, 이메일, 이름, 닉네임, 역할 정보를 포함합니다.
+ *
+ * <p>주로 프레젠테이션 계층에서 사용되며, 외부에 노출할 사용자 정보를 캡슐화합니다.
+ *
+ * @author dooya
+ */
+public record UserResponse(
+        Long id,
+        String email,
+        String name,
+        String nickName,
+        Role role
+) {
+}

--- a/src/test/java/dooya/see/admin/presentation/AdminControllerTest.java
+++ b/src/test/java/dooya/see/admin/presentation/AdminControllerTest.java
@@ -1,14 +1,25 @@
 package dooya.see.admin.presentation;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import dooya.see.auth.util.JwtUtil;
+import dooya.see.common.AdminFixture;
+import dooya.see.common.UserFixture;
+import dooya.see.user.domain.Role;
+import dooya.see.user.domain.User;
+import dooya.see.user.infrastructure.UserJpaRepository;
+import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -20,10 +31,37 @@ public class AdminControllerTest {
     private MockMvc mockMvc;
 
     @Autowired
-    private ObjectMapper objectMapper;
+    private UserJpaRepository userJpaRepository;
+
+    @Autowired
+    private JwtUtil jwtUtil;
 
     @DisplayName("유저 목록 조회 성공 테스트")
     @Test
-    void admin_userSelect_success() {
+    void admin_userSelect_success() throws Exception {
+        // Arrange
+        User testAdmin = userJpaRepository.save(AdminFixture.testAdmin());
+        String testToken = jwtUtil.createAccessToken(testAdmin.getId(), testAdmin.getEmail(), Role.valueOf(testAdmin.getRole().getRoleName()));
+
+        // Act & Assert
+        mockMvc.perform(get("/api/admin")
+                        .cookie(new Cookie("Authorization", testToken))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+    }
+
+    @DisplayName("유저 목록 조회 실패 테스트")
+    @Test
+    void admin_userSelect_fail() throws Exception {
+        User testAdmin = userJpaRepository.save(UserFixture.testUser());
+        String testToken = jwtUtil.createAccessToken(testAdmin.getId(), testAdmin.getEmail(), Role.valueOf(testAdmin.getRole().getRoleName()));
+
+        // Act & Assert
+        mockMvc.perform(get("/api/admin")
+                        .cookie(new Cookie("Authorization", testToken))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.status").value(false))
+                .andExpect(jsonPath("$.message").value("접근 권한이 없는 사용자입니다."));
     }
 }

--- a/src/test/java/dooya/see/admin/presentation/AdminControllerTest.java
+++ b/src/test/java/dooya/see/admin/presentation/AdminControllerTest.java
@@ -1,0 +1,29 @@
+package dooya.see.admin.presentation;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Sql("classpath:init.sql")
+public class AdminControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @DisplayName("유저 목록 조회 성공 테스트")
+    @Test
+    void admin_userSelect_success() {
+    }
+}

--- a/src/test/java/dooya/see/common/AdminFixture.java
+++ b/src/test/java/dooya/see/common/AdminFixture.java
@@ -1,0 +1,17 @@
+package dooya.see.common;
+
+import dooya.see.user.domain.Role;
+import dooya.see.user.domain.User;
+
+public class AdminFixture {
+
+    public static User testAdmin() {
+        return User.builder()
+                .email("test@see.com")
+                .name("testName")
+                .password("$2a$10$DOWSDdkg2YqXWB3S1.CzHeeI6qHtDc0lYBFfN4y3pFehUcbDoztYm")
+                .nickName("testNickName")
+                .role(Role.ADMIN)
+                .build();
+    }
+}

--- a/src/test/java/dooya/see/user/application/UserQueryServiceTest.java
+++ b/src/test/java/dooya/see/user/application/UserQueryServiceTest.java
@@ -4,6 +4,7 @@ import dooya.see.common.exception.CustomException;
 import dooya.see.common.exception.ErrorCode;
 import dooya.see.user.application.dto.UserResult;
 import dooya.see.user.application.service.impl.UserQueryServiceImpl;
+import dooya.see.user.domain.Role;
 import dooya.see.user.domain.User;
 import dooya.see.user.domain.UserRepository;
 import org.junit.jupiter.api.DisplayName;
@@ -13,6 +14,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.List;
 import java.util.Optional;
 
 import static dooya.see.common.UserFixture.*;
@@ -66,5 +68,24 @@ public class UserQueryServiceTest {
                 .hasMessageContaining("존재하지 않는 사용자입니다.");
 
         then(userRepository).should(times(1)).findByEmail(testUser.getEmail());
+    }
+
+    @DisplayName("권한이 USER인 유저 모두 조회 성공 테스트")
+    @Test
+    void user_getRoleUsers_success() {
+        // Arrange
+        User testUser1 = testUser();
+        User testUser2 = testUser();
+        List<User> users = List.of(testUser1, testUser2);
+
+        // Act
+        given(userRepository.findByRole(Role.USER)).willReturn(users);
+
+        // Assert
+        List<UserResult> results = userQueryService.getUsers();
+
+        assertThat(results).hasSize(2);
+
+        then(userRepository).should(times(1)).findByRole(Role.USER);
     }
 }

--- a/src/test/java/dooya/see/user/presentation/UserPresentationMapperTest.java
+++ b/src/test/java/dooya/see/user/presentation/UserPresentationMapperTest.java
@@ -101,4 +101,22 @@ public class UserPresentationMapperTest {
         // Assert
         assertThat(response.message()).isEqualTo(result.message());
     }
+
+    @DisplayName("UserResult를 UserResponse로 정상 반환한다")
+    @Test
+    void convert_UserResult_to_UserResponse() {
+        // Arrange
+        UserResult result = testUserResult();
+
+        // Act
+        UserResponse response = toResponse(result);
+
+        // Assert
+        assertAll(
+                () -> assertThat(response.email()).isEqualTo(result.email()),
+                () -> assertThat(response.name()).isEqualTo(result.name()),
+                () -> assertThat(response.nickName()).isEqualTo(result.nickName()),
+                () -> assertThat(response.role()).isEqualTo(result.role())
+        );
+    }
 }


### PR DESCRIPTION
## 📌 Issue

<!-- 해결하려는 이슈 번호나 주제를 명확하게 적어주세요. -->

- 관련 이슈: #30

---

## 🧐 현재 상황

<!-- 현재 발생한 문제, 개선이 필요한 사항을 간략히 설명해주세요. -->

- 관리자가 유저 목록을 조회할수 있도록 구현

---

## 🎯 목표

<!-- 이슈를 통해 달성하고자 하는 목표를 설명해주세요. -->

- 유저 목록 조회 가능

---

## 🛠 작업 내용

- 작업 할 내용을 입력해주세요.

- [x] Controller 구현
- [x] Service에 메서드 추가
- [x] 테스트 작성

---

## 🚀 기타 사항

<!-- 리뷰어가 추가적으로 알아야 할 사항이 있다면 기재해주세요. -->

- 추가적인 내용을 작성해주세요.(참고 자료, 협업 내용)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 관리자를 위한 사용자 목록 조회 API 엔드포인트가 추가되었습니다. (GET /api/admin)
- **버그 수정**
    - 없음
- **테스트**
    - 관리자 사용자 목록 조회 API의 성공 및 권한 없는 접근에 대한 테스트가 추가되었습니다.
    - 사용자 역할별 조회, DTO 변환에 대한 단위 테스트 및 테스트 유틸리티가 추가되었습니다.
- **문서화**
    - 사용자 정보 응답 객체에 대한 설명이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->