### PR TITLE
게시글 조회 기능 추가 (모든 게시글)

### DIFF
--- a/src/main/java/dooya/see/auth/config/SecurityConfig.java
+++ b/src/main/java/dooya/see/auth/config/SecurityConfig.java
@@ -9,6 +9,7 @@ import dooya.see.user.domain.Role;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -43,10 +44,13 @@ public class SecurityConfig {
         // HTTP Basic 인증 비활성화 (JWT 사용 시 필요 없음)
         http.httpBasic(AbstractHttpConfigurer::disable);
 
-        // 경로별 인가 작업
         http.authorizeHttpRequests((auth) -> auth
                 .requestMatchers("/api/users/**").permitAll()
                 .requestMatchers("/api/auth/**").permitAll()
+                .requestMatchers(HttpMethod.GET, "/api/post/**").permitAll()
+                .requestMatchers(HttpMethod.POST, "/api/post/**").authenticated()
+                .requestMatchers(HttpMethod.PUT, "/api/post/**").authenticated()
+                .requestMatchers(HttpMethod.DELETE, "/api/post/**").authenticated()
                 .requestMatchers("/api/admin").hasAnyAuthority(Role.ADMIN.getRoleSecurity())
                 .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html", "/webjars/**").permitAll()
                 .anyRequest().authenticated());

--- a/src/main/java/dooya/see/common/exception/ErrorCode.java
+++ b/src/main/java/dooya/see/common/exception/ErrorCode.java
@@ -17,7 +17,7 @@ public enum ErrorCode {
     USER_NOT_MATCH_LOGIN_INFO(HttpStatus.BAD_REQUEST, "로그인 정보가 일치하지 않습니다."),
 
     // Post Error
-    POST_NOT_FOUNT(HttpStatus.NOT_FOUND, "게시글이 존재하지 않습니다."),
+    POST_NOT_FOUND(HttpStatus.NOT_FOUND, "게시글이 존재하지 않습니다."),
 
     // Role Error
     ROLE_INVALID(HttpStatus.BAD_REQUEST, "유효하지 않은 권한입니다."),

--- a/src/main/java/dooya/see/common/exception/ErrorCode.java
+++ b/src/main/java/dooya/see/common/exception/ErrorCode.java
@@ -16,6 +16,9 @@ public enum ErrorCode {
     // Login Error
     USER_NOT_MATCH_LOGIN_INFO(HttpStatus.BAD_REQUEST, "로그인 정보가 일치하지 않습니다."),
 
+    // Post Error
+    POST_NOT_FOUNT(HttpStatus.NOT_FOUND, "게시글이 존재하지 않습니다."),
+
     // Role Error
     ROLE_INVALID(HttpStatus.BAD_REQUEST, "유효하지 않은 권한입니다."),
     FORBIDDEN_ACCESS(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),

--- a/src/main/java/dooya/see/post/application/dto/PostApplicationMapper.java
+++ b/src/main/java/dooya/see/post/application/dto/PostApplicationMapper.java
@@ -1,7 +1,12 @@
 package dooya.see.post.application.dto;
 
 import dooya.see.post.domain.Post;
+import dooya.see.user.application.dto.UserApplicationMapper;
+import dooya.see.user.application.dto.UserResult;
 import dooya.see.user.domain.User;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class PostApplicationMapper {
 
@@ -20,5 +25,9 @@ public class PostApplicationMapper {
                 post.getTitle(),
                 post.getContent()
         );
+    }
+
+    public static List<PostResult> toResults(List<Post> posts) {
+        return posts.stream().map(PostApplicationMapper::toResult).collect(Collectors.toList());
     }
 }

--- a/src/main/java/dooya/see/post/application/dto/PostApplicationMapper.java
+++ b/src/main/java/dooya/see/post/application/dto/PostApplicationMapper.java
@@ -1,8 +1,6 @@
 package dooya.see.post.application.dto;
 
 import dooya.see.post.domain.Post;
-import dooya.see.user.application.dto.UserApplicationMapper;
-import dooya.see.user.application.dto.UserResult;
 import dooya.see.user.domain.User;
 
 import java.util.List;

--- a/src/main/java/dooya/see/post/application/service/PostQueryService.java
+++ b/src/main/java/dooya/see/post/application/service/PostQueryService.java
@@ -1,5 +1,9 @@
 package dooya.see.post.application.service;
 
+import dooya.see.post.application.dto.PostResult;
+
+import java.util.List;
+
 public interface PostQueryService {
-    void getPosts();
+    List<PostResult> getPosts();
 }

--- a/src/main/java/dooya/see/post/application/service/PostQueryService.java
+++ b/src/main/java/dooya/see/post/application/service/PostQueryService.java
@@ -1,8 +1,5 @@
 package dooya.see.post.application.service;
 
-import org.springframework.stereotype.Service;
-
-@Service
 public interface PostQueryService {
     void getPosts();
 }

--- a/src/main/java/dooya/see/post/application/service/PostQueryService.java
+++ b/src/main/java/dooya/see/post/application/service/PostQueryService.java
@@ -1,0 +1,8 @@
+package dooya.see.post.application.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public interface PostQueryService {
+    void getPosts();
+}

--- a/src/main/java/dooya/see/post/application/service/impl/PostQueryServiceImpl.java
+++ b/src/main/java/dooya/see/post/application/service/impl/PostQueryServiceImpl.java
@@ -2,14 +2,31 @@ package dooya.see.post.application.service.impl;
 
 import dooya.see.common.exception.CustomException;
 import dooya.see.common.exception.ErrorCode;
+import dooya.see.post.application.dto.PostApplicationMapper;
+import dooya.see.post.application.dto.PostResult;
 import dooya.see.post.application.service.PostQueryService;
+import dooya.see.post.domain.Post;
+import dooya.see.post.domain.PostRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
+@RequiredArgsConstructor
 public class PostQueryServiceImpl implements PostQueryService {
 
+    private final PostRepository postRepository;
+
+    @Transactional(readOnly = true)
     @Override
-    public void getPosts() {
-        throw new CustomException(ErrorCode.POST_NOT_FOUNT);
+    public List<PostResult> getPosts() {
+        List<Post> posts = postRepository.findAll();
+        if (posts.isEmpty()) {
+            throw new CustomException(ErrorCode.POST_NOT_FOUNT);
+        }
+
+        return PostApplicationMapper.toResults(posts);
     }
 }

--- a/src/main/java/dooya/see/post/application/service/impl/PostQueryServiceImpl.java
+++ b/src/main/java/dooya/see/post/application/service/impl/PostQueryServiceImpl.java
@@ -24,7 +24,7 @@ public class PostQueryServiceImpl implements PostQueryService {
     public List<PostResult> getPosts() {
         List<Post> posts = postRepository.findAll();
         if (posts.isEmpty()) {
-            throw new CustomException(ErrorCode.POST_NOT_FOUNT);
+            throw new CustomException(ErrorCode.POST_NOT_FOUND);
         }
 
         return PostApplicationMapper.toResults(posts);

--- a/src/main/java/dooya/see/post/application/service/impl/PostQueryServiceImpl.java
+++ b/src/main/java/dooya/see/post/application/service/impl/PostQueryServiceImpl.java
@@ -1,0 +1,15 @@
+package dooya.see.post.application.service.impl;
+
+import dooya.see.common.exception.CustomException;
+import dooya.see.common.exception.ErrorCode;
+import dooya.see.post.application.service.PostQueryService;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PostQueryServiceImpl implements PostQueryService {
+
+    @Override
+    public void getPosts() {
+        throw new CustomException(ErrorCode.POST_NOT_FOUNT);
+    }
+}

--- a/src/main/java/dooya/see/post/application/service/impl/PostQueryServiceImpl.java
+++ b/src/main/java/dooya/see/post/application/service/impl/PostQueryServiceImpl.java
@@ -1,7 +1,5 @@
 package dooya.see.post.application.service.impl;
 
-import dooya.see.common.exception.CustomException;
-import dooya.see.common.exception.ErrorCode;
 import dooya.see.post.application.dto.PostApplicationMapper;
 import dooya.see.post.application.dto.PostResult;
 import dooya.see.post.application.service.PostQueryService;
@@ -23,9 +21,6 @@ public class PostQueryServiceImpl implements PostQueryService {
     @Override
     public List<PostResult> getPosts() {
         List<Post> posts = postRepository.findAll();
-        if (posts.isEmpty()) {
-            throw new CustomException(ErrorCode.POST_NOT_FOUND);
-        }
 
         return PostApplicationMapper.toResults(posts);
     }

--- a/src/main/java/dooya/see/post/domain/PostRepository.java
+++ b/src/main/java/dooya/see/post/domain/PostRepository.java
@@ -1,5 +1,8 @@
 package dooya.see.post.domain;
 
+import java.util.List;
+
 public interface PostRepository {
     Post save(Post post);
+    List<Post> findAll();
 }

--- a/src/main/java/dooya/see/post/infrastructure/PostJpaRepository.java
+++ b/src/main/java/dooya/see/post/infrastructure/PostJpaRepository.java
@@ -3,5 +3,8 @@ package dooya.see.post.infrastructure;
 import dooya.see.post.domain.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface PostJpaRepository extends JpaRepository<Post, Long> {
+    List<Post> findAll();
 }

--- a/src/main/java/dooya/see/post/infrastructure/PostRepositoryImpl.java
+++ b/src/main/java/dooya/see/post/infrastructure/PostRepositoryImpl.java
@@ -6,6 +6,8 @@ import lombok.Builder;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 @RequiredArgsConstructor
 @Builder
@@ -16,5 +18,10 @@ public class PostRepositoryImpl implements PostRepository {
     @Override
     public Post save(Post post) {
         return postJpaRepository.save(post);
+    }
+
+    @Override
+    public List<Post> findAll() {
+        return postJpaRepository.findAll();
     }
 }

--- a/src/main/java/dooya/see/post/presentation/PostController.java
+++ b/src/main/java/dooya/see/post/presentation/PostController.java
@@ -10,10 +10,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
 
@@ -34,5 +31,11 @@ public class PostController {
         PostResult result = postCreateService.createPost(email, command);
 
         return ResponseEntity.created(URI.create("/api/post/" + result.id())).body(toResponse(result));
+    }
+
+    @GetMapping
+    public ResponseEntity<PostResponse> getPosts() {
+
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/dooya/see/post/presentation/PostController.java
+++ b/src/main/java/dooya/see/post/presentation/PostController.java
@@ -1,6 +1,7 @@
 package dooya.see.post.presentation;
 
 import dooya.see.auth.domain.LoginUser;
+import dooya.see.post.application.service.PostQueryService;
 import dooya.see.post.application.dto.PostCommand;
 import dooya.see.post.application.dto.PostResult;
 import dooya.see.post.application.service.PostCreateService;
@@ -22,6 +23,7 @@ import static dooya.see.post.presentation.dto.PostPresentationMapper.*;
 public class PostController {
 
     private final PostCreateService postCreateService;
+    private final PostQueryService postQueryService;
 
     @PostMapping
     public ResponseEntity<PostResponse> post(@AuthenticationPrincipal LoginUser loginUser,
@@ -35,7 +37,7 @@ public class PostController {
 
     @GetMapping
     public ResponseEntity<PostResponse> getPosts() {
-
+        postQueryService.getPosts();
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/dooya/see/post/presentation/PostController.java
+++ b/src/main/java/dooya/see/post/presentation/PostController.java
@@ -5,8 +5,10 @@ import dooya.see.post.application.service.PostQueryService;
 import dooya.see.post.application.dto.PostCommand;
 import dooya.see.post.application.dto.PostResult;
 import dooya.see.post.application.service.PostCreateService;
+import dooya.see.post.presentation.dto.PostPresentationMapper;
 import dooya.see.post.presentation.dto.PostRequest;
 import dooya.see.post.presentation.dto.PostResponse;
+import dooya.see.user.presentation.dto.UserPresentationMapper;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -14,6 +16,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
+import java.util.List;
 
 import static dooya.see.post.presentation.dto.PostPresentationMapper.*;
 
@@ -36,8 +39,9 @@ public class PostController {
     }
 
     @GetMapping
-    public ResponseEntity<PostResponse> getPosts() {
-        postQueryService.getPosts();
-        return ResponseEntity.ok().build();
+    public ResponseEntity<List<PostResponse>> getPosts() {
+        List<PostResult> posts = postQueryService.getPosts();
+
+        return ResponseEntity.ok(PostPresentationMapper.toResponses(posts));
     }
 }

--- a/src/main/java/dooya/see/post/presentation/dto/PostPresentationMapper.java
+++ b/src/main/java/dooya/see/post/presentation/dto/PostPresentationMapper.java
@@ -2,6 +2,11 @@ package dooya.see.post.presentation.dto;
 
 import dooya.see.post.application.dto.PostCommand;
 import dooya.see.post.application.dto.PostResult;
+import dooya.see.user.application.dto.UserResult;
+import dooya.see.user.presentation.dto.UserPresentationMapper;
+import dooya.see.user.presentation.dto.UserResponse;
+
+import java.util.List;
 
 public class PostPresentationMapper {
 
@@ -19,5 +24,11 @@ public class PostPresentationMapper {
                 result.title(),
                 result.content()
         );
+    }
+
+    public static List<PostResponse> toResponses(List<PostResult> results) {
+        return results.stream()
+                .map(PostPresentationMapper::toResponse)
+                .toList();
     }
 }

--- a/src/test/java/dooya/see/common/PostFixture.java
+++ b/src/test/java/dooya/see/common/PostFixture.java
@@ -5,6 +5,8 @@ import dooya.see.post.application.dto.PostResult;
 import dooya.see.post.domain.Post;
 import dooya.see.post.presentation.dto.PostRequest;
 
+import java.util.List;
+
 public class PostFixture {
 
     public static PostRequest request() {
@@ -30,6 +32,14 @@ public class PostFixture {
                 UserFixture.testUser(),
                 "테스트용 게시글 제목",
                 "테스트용 게시물 내용입니다."
+        );
+    }
+
+    public static List<Post> testPosts() {
+        return List.of(
+                new Post(90L, UserFixture.testUser(), "테스트용 게시글 제목 1", "테스트용 게시물 내용 1입니다."),
+                new Post(91L, UserFixture.testUser(), "테스트용 게시글 제목 2", "테스트용 게시물 내용 2입니다."),
+                new Post(92L, UserFixture.testUser(), "테스트용 게시글 제목 3", "테스트용 게시물 내용 3입니다.")
         );
     }
 }

--- a/src/test/java/dooya/see/post/application/PostQueryServiceTest.java
+++ b/src/test/java/dooya/see/post/application/PostQueryServiceTest.java
@@ -3,44 +3,60 @@ package dooya.see.post.application;
 import dooya.see.common.PostFixture;
 import dooya.see.common.exception.CustomException;
 import dooya.see.post.application.dto.PostResult;
-import dooya.see.post.application.service.PostQueryService;
 import dooya.see.post.application.service.impl.PostQueryServiceImpl;
-import dooya.see.post.domain.Post;
-import jakarta.servlet.http.Cookie;
+import dooya.see.post.domain.PostRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.http.MediaType;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Collections;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.BDDMockito.*;
 
+@ExtendWith(MockitoExtension.class)
 public class PostQueryServiceTest {
 
-    private final PostQueryService postQueryService = new PostQueryServiceImpl();
+    @InjectMocks
+    private PostQueryServiceImpl postQueryService;
+
+    @Mock
+    private PostRepository postRepository;
 
     @DisplayName("게시글 조회 실패 테스트 - 게시글이 없는 경우")
     @Test
-    void noPost() {
+    void getPosts_shouldThrowException_whenNoPostsExist() {
+        // given
+        given(postRepository.findAll()).willReturn(Collections.emptyList());
+
+        // when && then
         assertThatCode(postQueryService::getPosts)
                 .isInstanceOf(CustomException.class)
                 .hasMessageContaining("게시글이 존재하지 않습니다.");
     }
 
+    @DisplayName("게시글 조회 성공 테스트")
+    @Test
+    void getPosts_shouldReturnList_whenPostsExist() {
+        // given
+        given(postRepository.findAll()).willReturn(PostFixture.testPosts());
 
-//    @Test
-//    void name() {
-//        // Arrange
-//        Post post = PostFixture.testPost();
-//
-//        // Act
-//        List<PostResult> result = postQueryService.getPosts();
-//
-//        // Assert
-//        assertThat(result.get(0).id()).isEqualTo(post.getId());
-//    }
+        // when
+        List<PostResult> result = postQueryService.getPosts();
+
+        // then
+        assertAll(
+                () -> assertThat(result).hasSize(3),
+                () -> assertThat(result.getFirst().title()).isEqualTo("테스트용 게시글 제목 1"),
+                () -> assertThat(result.getFirst().nickName()).isEqualTo("testNickName"),
+                () -> assertThat(result.get(1).content()).contains("테스트용 게시물 내용 2입니다."),
+                () -> assertThat(result.get(2).id()).isNotNull()
+        );
+    }
 }

--- a/src/test/java/dooya/see/post/application/PostQueryServiceTest.java
+++ b/src/test/java/dooya/see/post/application/PostQueryServiceTest.java
@@ -1,7 +1,6 @@
 package dooya.see.post.application;
 
 import dooya.see.common.PostFixture;
-import dooya.see.common.exception.CustomException;
 import dooya.see.post.application.dto.PostResult;
 import dooya.see.post.application.service.impl.PostQueryServiceImpl;
 import dooya.see.post.domain.PostRepository;
@@ -12,11 +11,9 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.Collections;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.BDDMockito.*;
 
@@ -28,18 +25,6 @@ public class PostQueryServiceTest {
 
     @Mock
     private PostRepository postRepository;
-
-    @DisplayName("게시글 조회 실패 테스트 - 게시글이 없는 경우")
-    @Test
-    void getPosts_shouldThrowException_whenNoPostsExist() {
-        // given
-        given(postRepository.findAll()).willReturn(Collections.emptyList());
-
-        // when && then
-        assertThatCode(postQueryService::getPosts)
-                .isInstanceOf(CustomException.class)
-                .hasMessageContaining("게시글이 존재하지 않습니다.");
-    }
 
     @DisplayName("게시글 조회 성공 테스트")
     @Test

--- a/src/test/java/dooya/see/post/application/PostQueryServiceTest.java
+++ b/src/test/java/dooya/see/post/application/PostQueryServiceTest.java
@@ -1,0 +1,46 @@
+package dooya.see.post.application;
+
+import dooya.see.common.PostFixture;
+import dooya.see.common.exception.CustomException;
+import dooya.see.post.application.dto.PostResult;
+import dooya.see.post.application.service.PostQueryService;
+import dooya.see.post.application.service.impl.PostQueryServiceImpl;
+import dooya.see.post.domain.Post;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+public class PostQueryServiceTest {
+
+    private final PostQueryService postQueryService = new PostQueryServiceImpl();
+
+    @DisplayName("게시글 조회 실패 테스트 - 게시글이 없는 경우")
+    @Test
+    void noPost() {
+        assertThatCode(postQueryService::getPosts)
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining("게시글이 존재하지 않습니다.");
+    }
+
+
+//    @Test
+//    void name() {
+//        // Arrange
+//        Post post = PostFixture.testPost();
+//
+//        // Act
+//        List<PostResult> result = postQueryService.getPosts();
+//
+//        // Assert
+//        assertThat(result.get(0).id()).isEqualTo(post.getId());
+//    }
+}

--- a/src/test/java/dooya/see/post/presentation/PostControllerTest.java
+++ b/src/test/java/dooya/see/post/presentation/PostControllerTest.java
@@ -1,104 +1,20 @@
 package dooya.see.post.presentation;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import dooya.see.auth.util.JwtUtil;
-import dooya.see.common.PostFixture;
-import dooya.see.common.UserFixture;
-import dooya.see.post.presentation.dto.PostRequest;
-import dooya.see.user.domain.User;
-import dooya.see.user.infrastructure.UserJpaRepository;
-import jakarta.servlet.http.Cookie;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.http.MediaType;
-import org.springframework.test.context.jdbc.Sql;
-import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 
-import java.util.stream.Stream;
+import static org.mockito.BDDMockito.*;
 
-import static dooya.see.common.PostFixture.*;
-import static dooya.see.common.UserFixture.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-@SpringBootTest
-@AutoConfigureMockMvc
-@Sql("classpath:init.sql")
+@WebMvcTest(PostController.class)
 public class PostControllerTest {
 
-    @Autowired
-    private MockMvc mockMvc;
+    private PostQueryService postQueryService;
 
-    @Autowired
-    private ObjectMapper objectMapper;
-
-    @Autowired
-    private UserJpaRepository userJpaRepository;
-
-    @Autowired
-    private JwtUtil jwtUtil;
-
-    private String testToken;
-    private User testUser;
-
-    @BeforeEach
-    void setUp() {
-        testUser = userJpaRepository.save(testUser());
-        testToken = jwtUtil.createAccessToken(testUser.getId(), testUser.getEmail(), testUser.getRole());
-    }
-
-    @DisplayName("게시글 작성 성공 테스트")
     @Test
-    void user_post_success() throws Exception {
-        // Arrange
-        PostRequest request = request();
-
-        // Act && Assert
-        mockMvc.perform(post("/api/post")
-                        .cookie(new Cookie("Authorization", testToken))
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.id").exists())
-                .andExpect(jsonPath("$.nickName").value(testUser.getNickName()))
-                .andExpect(jsonPath("$.title").value(request.title()))
-                .andExpect(jsonPath("$.content").value(request.content()));
+    void name() {
+        // given
+        // when
+        // then
+        then(postQueryService).should().getPosts();
     }
-
-    @DisplayName("게시글 작성 실패 테스트 - 개별 필드 유효성 검증")
-    @ParameterizedTest(name = "{index} => 필드 = {0}, 메시지 = {1}")
-    @MethodSource("invalidFieldProvider")
-    void post_fail_invalidField(PostRequest request, String field, String message) throws Exception {
-        mockMvc.perform(post("/api/post")
-                        .cookie(new Cookie("Authorization", testToken))
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.status").value(false))
-                .andExpect(jsonPath("$.message").value("잘못된 요청입니다."))
-                .andExpect(jsonPath("$.validationErrors[0].field").value(field))
-                .andExpect(jsonPath("$.validationErrors[0].message").value(message));
-    }
-
-    private static Stream<Arguments> invalidFieldProvider() {
-        return Stream.of(
-                Arguments.of(
-                        request().toBuilder().title("").build(),
-                        "title", "제목은 비어 있을 수 없습니다"
-                ),
-                Arguments.of(
-                        request().toBuilder().content("").build(),
-                        "content", "내용은 비어 있을 수 없습니다"
-                )
-        );
-    }
-
 }

--- a/src/test/java/dooya/see/post/presentation/PostControllerTest.java
+++ b/src/test/java/dooya/see/post/presentation/PostControllerTest.java
@@ -1,6 +1,7 @@
 package dooya.see.post.presentation;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import dooya.see.auth.config.SecurityConfig;
 import dooya.see.auth.domain.LoginUser;
 import dooya.see.auth.util.JwtUtil;
 import dooya.see.common.PostFixture;
@@ -13,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -25,6 +27,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(PostController.class)
+@Import(SecurityConfig.class)
 @AutoConfigureMockMvc
 public class PostControllerTest {
 
@@ -68,13 +71,8 @@ public class PostControllerTest {
     @DisplayName("GET 요청 시 postQueryService.getPosts() 호출 여부 검증")
     @Test
     void post_WhenCalled_InvokesGetPost() throws Exception {
-        // given
-        LoginUser loginUser = new LoginUser(1L, "email", "USER");
-
         // when
-        mockMvc.perform(get("/api/post")
-                        .with(user(loginUser))
-                        .with(csrf()))
+        mockMvc.perform(get("/api/post"))
                 .andExpect(status().isOk());
 
         // then

--- a/src/test/java/dooya/see/post/presentation/PostControllerTest.java
+++ b/src/test/java/dooya/see/post/presentation/PostControllerTest.java
@@ -1,19 +1,82 @@
 package dooya.see.post.presentation;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dooya.see.auth.domain.LoginUser;
+import dooya.see.auth.util.JwtUtil;
+import dooya.see.common.PostFixture;
+import dooya.see.post.application.service.PostQueryService;
+import dooya.see.post.application.dto.PostCommand;
+import dooya.see.post.application.service.PostCreateService;
+import dooya.see.post.presentation.dto.PostRequest;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
 
 import static org.mockito.BDDMockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(PostController.class)
+@AutoConfigureMockMvc
 public class PostControllerTest {
 
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private JwtUtil jwtUtil;
+
+    @MockitoBean
     private PostQueryService postQueryService;
 
+    @MockitoBean
+    private PostCreateService postCreateService;
+
+    @DisplayName("POST 요청 시 postCreateService.createPost() 호출 여부 검증")
     @Test
-    void name() {
+    void post_WhenCalled_InvokesCreatePost() throws Exception {
         // given
+        PostRequest request = PostFixture.request();
+        PostCommand command = PostFixture.command();
+        LoginUser loginUser = new LoginUser(1L, "email", "USER");
+
+        given(postCreateService.createPost(anyString(), any(PostCommand.class))).willReturn(PostFixture.result());
+
         // when
+        mockMvc.perform(post("/api/post")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+                        .with(user(loginUser))
+                        .with(csrf()))
+                .andExpect(status().isCreated());
+
+        // then
+        then(postCreateService).should().createPost("email", command);
+    }
+
+    @DisplayName("GET 요청 시 postQueryService.getPosts() 호출 여부 검증")
+    @Test
+    void post_WhenCalled_InvokesGetPost() throws Exception {
+        // given
+        LoginUser loginUser = new LoginUser(1L, "email", "USER");
+
+        // when
+        mockMvc.perform(get("/api/post")
+                        .with(user(loginUser))
+                        .with(csrf()))
+                .andExpect(status().isOk());
+
         // then
         then(postQueryService).should().getPosts();
     }

--- a/src/test/java/dooya/see/post/presentation/PostIntegrationTest.java
+++ b/src/test/java/dooya/see/post/presentation/PostIntegrationTest.java
@@ -1,0 +1,115 @@
+package dooya.see.post.presentation;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dooya.see.auth.util.JwtUtil;
+import dooya.see.post.presentation.dto.PostRequest;
+import dooya.see.user.domain.User;
+import dooya.see.user.infrastructure.UserJpaRepository;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.stream.Stream;
+
+import static dooya.see.common.PostFixture.*;
+import static dooya.see.common.UserFixture.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Sql("classpath:init.sql")
+public class PostIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private UserJpaRepository userJpaRepository;
+
+    @Autowired
+    private JwtUtil jwtUtil;
+
+    private String testToken;
+    private User testUser;
+
+    @BeforeEach
+    void setUp() {
+        testUser = userJpaRepository.save(testUser());
+        testToken = jwtUtil.createAccessToken(testUser.getId(), testUser.getEmail(), testUser.getRole());
+    }
+
+    @DisplayName("게시글 작성 성공 테스트")
+    @Test
+    void user_post_success() throws Exception {
+        // Arrange
+        PostRequest request = request();
+
+        // Act && Assert
+        mockMvc.perform(post("/api/post")
+                        .cookie(new Cookie("Authorization", testToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").exists())
+                .andExpect(jsonPath("$.nickName").value(testUser.getNickName()))
+                .andExpect(jsonPath("$.title").value(request.title()))
+                .andExpect(jsonPath("$.content").value(request.content()));
+    }
+
+    @DisplayName("게시글 작성 실패 테스트 - 개별 필드 유효성 검증")
+    @ParameterizedTest(name = "{index} => 필드 = {0}, 메시지 = {1}")
+    @MethodSource("invalidFieldProvider")
+    void post_fail_invalidField(PostRequest request, String field, String message) throws Exception {
+        mockMvc.perform(post("/api/post")
+                        .cookie(new Cookie("Authorization", testToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(false))
+                .andExpect(jsonPath("$.message").value("잘못된 요청입니다."))
+                .andExpect(jsonPath("$.validationErrors[0].field").value(field))
+                .andExpect(jsonPath("$.validationErrors[0].message").value(message));
+    }
+
+    private static Stream<Arguments> invalidFieldProvider() {
+        return Stream.of(
+                Arguments.of(
+                        request().toBuilder().title("").build(),
+                        "title", "제목은 비어 있을 수 없습니다"
+                ),
+                Arguments.of(
+                        request().toBuilder().content("").build(),
+                        "content", "내용은 비어 있을 수 없습니다"
+                )
+        );
+    }
+
+    @DisplayName("게시글 조회 성공 테스트")
+    @Test
+    void post_get_success() throws Exception {
+        // Arrange
+
+        // Act && Assert
+        mockMvc.perform(get("/api/post")
+                        .cookie(new Cookie("Authorization", testToken))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").exists());
+    }
+}

--- a/src/test/java/dooya/see/post/presentation/PostIntegrationTest.java
+++ b/src/test/java/dooya/see/post/presentation/PostIntegrationTest.java
@@ -120,15 +120,4 @@ public class PostIntegrationTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)));
     }
-
-    @DisplayName("게시글 조회 실패 테스트 - 게시글이 존재하지 않을 때")
-    @Test
-    void post_get_fail_notFound() throws Exception {
-        // Act && Assert
-        mockMvc.perform(get("/api/post")
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.status").value(false))
-                .andExpect(jsonPath("$.message").value("게시글이 존재하지 않습니다."));
-    }
 }

--- a/src/test/java/dooya/see/post/presentation/PostIntegrationTest.java
+++ b/src/test/java/dooya/see/post/presentation/PostIntegrationTest.java
@@ -104,12 +104,31 @@ public class PostIntegrationTest {
     @Test
     void post_get_success() throws Exception {
         // Arrange
+        saveTestPost();
 
         // Act && Assert
         mockMvc.perform(get("/api/post")
-                        .cookie(new Cookie("Authorization", testToken))
                         .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.id").exists());
+                .andExpect(status().isOk());
+    }
+
+    private void saveTestPost() throws Exception {
+        PostRequest request = request();
+
+        mockMvc.perform(post("/api/post")
+                        .cookie(new Cookie("Authorization", testToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)));
+    }
+
+    @DisplayName("게시글 조회 실패 테스트 - 게시글이 존재하지 않을 때")
+    @Test
+    void post_get_fail_notFound() throws Exception {
+        // Act && Assert
+        mockMvc.perform(get("/api/post")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.status").value(false))
+                .andExpect(jsonPath("$.message").value("게시글이 존재하지 않습니다."));
     }
 }

--- a/src/test/java/dooya/see/post/presentation/PostIntegrationTest.java
+++ b/src/test/java/dooya/see/post/presentation/PostIntegrationTest.java
@@ -109,7 +109,11 @@ public class PostIntegrationTest {
         // Act && Assert
         mockMvc.perform(get("/api/post")
                         .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").exists())
+                .andExpect(jsonPath("$[0].nickName").exists())
+                .andExpect(jsonPath("$[0].title").exists())
+                .andExpect(jsonPath("$[0].content").exists());
     }
 
     private void saveTestPost() throws Exception {
@@ -118,6 +122,7 @@ public class PostIntegrationTest {
         mockMvc.perform(post("/api/post")
                         .cookie(new Cookie("Authorization", testToken))
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)));
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated());
     }
 }


### PR DESCRIPTION
## 📌 Issue

<!-- 해결하려는 이슈 번호나 주제를 명확하게 적어주세요. -->

- 관련 이슈: #44

---

## 🧐 현재 상황

<!-- 현재 발생한 문제, 개선이 필요한 사항을 간략히 설명해주세요. -->

- 저장된 모든 게시글을 조회하는 기능

---

## 🎯 목표

<!-- 이슈를 통해 달성하고자 하는 목표를 설명해주세요. -->

- 저장된 모든 게시글을 조회 가능

---

## 🛠 작업 내용

- 작업 할 내용을 입력해주세요.

- [x] 테스트 부터 작성하여 기능 구현

---

## 🚀 기타 사항

<!-- 리뷰어가 추가적으로 알아야 할 사항이 있다면 기재해주세요. -->

- 추가적인 내용을 작성해주세요.(참고 자료, 협업 내용)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 모든 사용자가 인증 없이 게시글 목록을 조회할 수 있는 GET /api/post 엔드포인트가 추가되었습니다.
  - 게시글이 존재하지 않을 때 404 에러와 함께 안내 메시지가 제공됩니다.

- **버그 수정**
  - 게시글 관련 엔드포인트의 접근 권한이 HTTP 메서드별로 세분화되어, GET은 모두 허용되고, POST/PUT/DELETE는 인증된 사용자만 이용할 수 있도록 변경되었습니다.

- **테스트**
  - 게시글 조회 및 예외 상황에 대한 단위 테스트와 통합 테스트가 추가되었습니다.
  - 컨트롤러 테스트가 슬라이스 테스트로 리팩토링되어 테스트 효율성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->