### PR TITLE
유저 테스트 리팩터링 ControllerTest(통합테스트) -> IntegrationTest(통합테스트)로 명확하게 이름 변경 및 ControllerTest(단위테스트) 작성

### DIFF
--- a/src/test/java/dooya/see/common/UserFixture.java
+++ b/src/test/java/dooya/see/common/UserFixture.java
@@ -28,7 +28,7 @@ public class UserFixture {
     }
 
     public static UserSignUpCommand signUpCommand() {
-        return new UserSignUpCommand("test@see.com", "testName", "testPassword", "testNickName");
+        return new UserSignUpCommand("dooya@see.com", "testName", "testPassword", "testNickName");
     }
 
     public static UserUpdateCommand updateCommand() {
@@ -62,7 +62,7 @@ public class UserFixture {
     }
 
     public static UserResult testUserResult() {
-        return new UserResult(1L, "test@see.com", "testName", "testNickName", Role.of("USER"));
+        return new UserResult(1L, "dooya@see.com", "testName", "testNickName", Role.of("USER"));
     }
 
     public static PasswordUpdateResult passwordUpdateResult() {

--- a/src/test/java/dooya/see/user/presentation/UserControllerTest.java
+++ b/src/test/java/dooya/see/user/presentation/UserControllerTest.java
@@ -1,10 +1,18 @@
 package dooya.see.user.presentation;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import dooya.see.auth.config.SecurityConfig;
+import dooya.see.auth.domain.LoginUser;
 import dooya.see.auth.util.JwtUtil;
 import dooya.see.common.UserFixture;
+import dooya.see.user.application.dto.PasswordUpdateCommand;
+import dooya.see.user.application.dto.UserSignUpCommand;
+import dooya.see.user.application.dto.UserUpdateCommand;
+import dooya.see.user.application.service.UserQueryService;
+import dooya.see.user.application.service.UserSignUpService;
+import dooya.see.user.application.service.UserUpdateService;
+import dooya.see.user.application.service.UserValidator;
 import dooya.see.user.domain.User;
-import dooya.see.user.infrastructure.UserJpaRepository;
 import dooya.see.user.presentation.dto.PasswordUpdateRequest;
 import dooya.see.user.presentation.dto.UserSignUpRequest;
 import dooya.see.user.presentation.dto.UserUpdateRequest;
@@ -12,32 +20,26 @@ import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
-import java.util.stream.Stream;
+import static dooya.see.common.UserFixture.signUpRequest;
 
-import static dooya.see.common.UserFixture.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@SpringBootTest
+@WebMvcTest(UserController.class)
+@Import(SecurityConfig.class)
 @AutoConfigureMockMvc
-@ActiveProfiles("test")
-@Sql("classpath:init.sql")
-class UserControllerTest {
+public class UserControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
@@ -45,216 +47,129 @@ class UserControllerTest {
     @Autowired
     private ObjectMapper objectMapper;
 
-    @Autowired
+    @MockitoBean
     private JwtUtil jwtUtil;
 
-    @Autowired
-    private UserJpaRepository userJpaRepository;
+    @MockitoBean
+    private UserQueryService userQueryService;
 
-    @Autowired
+    @MockitoBean
+    private UserSignUpService userSignUpService;
+
+    @MockitoBean
+    private UserUpdateService userUpdateService;
+
+    @MockitoBean
+    private UserValidator userValidator;
+
+    @MockitoBean
     private PasswordEncoder passwordEncoder;
 
-    private User testUser;
     private String testToken;
 
     @BeforeEach
     void setUp() {
-        testUser = userJpaRepository.save(UserFixture.mockUser(passwordEncoder));
+        User testUser = UserFixture.mockUser(passwordEncoder);
         testToken = jwtUtil.createAccessToken(testUser.getId(), testUser.getEmail(), testUser.getRole());
     }
 
-    @DisplayName("유저 회원가입 성공 테스트")
+    @DisplayName("POST 요청 시 userSignUpService.userSignUp() 호출 여부 검증")
     @Test
-    void user_signUp_success() throws Exception {
+    void post_WhenCalled_InvokesUserSignUp() throws Exception {
+        // given
         UserSignUpRequest request = signUpRequest();
+        UserSignUpCommand command = UserFixture.signUpCommand();
 
+        given(userSignUpService.userSignUp(any(UserSignUpCommand.class))).willReturn(UserFixture.testUserResult());
+
+        // when
         mockMvc.perform(post("/api/users")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.id").exists())
-                .andExpect(jsonPath("$.email").value(request.email()))
-                .andExpect(jsonPath("$.name").value(request.name()))
-                .andExpect(jsonPath("$.nickName").value(request.nickName()))
-                .andExpect(jsonPath("$.role").value("USER"));
+                .andExpect(status().isCreated());
+
+        // then
+        then(userSignUpService).should().userSignUp(command);
     }
 
-    @DisplayName("유저 회원가입 실패 테스트 - 개별 필드 유효성 검증")
-    @ParameterizedTest(name = "{index} => 필드 = {0}, 메시지 = {1}")
-    @MethodSource("invalidFieldProvider")
-    void user_signUp_fail_invalidField(UserSignUpRequest request, String field, String message) throws Exception {
-        mockMvc.perform(post("/api/users")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.status").value(false))
-                .andExpect(jsonPath("$.message").value("잘못된 요청입니다."))
-                .andExpect(jsonPath("$.validationErrors[0].field").value(field))
-                .andExpect(jsonPath("$.validationErrors[0].message").value(message));
-    }
-
-    @DisplayName("유저 회원가입 실패 테스트 - 모든 필드가 공란일때")
+    @DisplayName("GET 요청 시 userQueryService.getUserByEmail(email) 호출 여부 검증")
     @Test
-    void user_signUp_fail_allFieldsInvalid() throws Exception {
-        UserSignUpRequest request = signUpRequest().toBuilder()
-                .email("")
-                .name("")
-                .password("")
-                .nickName("")
-                .build();
+    void get_WhenCalled_InvokeGetUserByEmail() throws Exception {
+        // given
+        LoginUser loginUser = new LoginUser(1L, "email", "USER");
 
-        mockMvc.perform(post("/api/users")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.status").value(false))
-                .andExpect(jsonPath("$.message").value("잘못된 요청입니다."))
-                .andExpect(jsonPath("$.validationErrors[?(@.field=='email')].message").value("이메일은 비어 있을 수 없습니다"))
-                .andExpect(jsonPath("$.validationErrors[?(@.field=='name')].message").value("이름은 비어 있을 수 없습니다"))
-                .andExpect(jsonPath("$.validationErrors[?(@.field=='password')].message").value("비밀번호는 비어 있을 수 없습니다"))
-                .andExpect(jsonPath("$.validationErrors[?(@.field=='nickName')].message").value("닉네임은 비어 있을 수 없습니다"));
-    }
+        given(userQueryService.getUserByEmail(anyString())).willReturn(UserFixture.testUserResult());
 
-    private static Stream<Arguments> invalidFieldProvider() {
-        return Stream.of(
-                Arguments.of(
-                        signUpRequest().toBuilder().email("").build(),
-                        "email", "이메일은 비어 있을 수 없습니다"
-                ),
-                Arguments.of(
-                        signUpRequest().toBuilder().name("").build(),
-                        "name", "이름은 비어 있을 수 없습니다"
-                ),
-                Arguments.of(
-                        signUpRequest().toBuilder().password("").build(),
-                        "password", "비밀번호는 비어 있을 수 없습니다"
-                ),
-                Arguments.of(
-                        signUpRequest().toBuilder().nickName("").build(),
-                        "nickName", "닉네임은 비어 있을 수 없습니다"
-                )
-        );
-    }
-
-    @DisplayName("토큰에 포함된 이메일로 유저 조회 성공테스트")
-    @Test
-    void findByToken_user_success() throws Exception {
-        // Act & Assert
+        // when
         mockMvc.perform(get("/api/users")
                         .cookie(new Cookie("Authorization", testToken))
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.id").value(testUser.getId()))
-                .andExpect(jsonPath("$.email").value(testUser.getEmail()))
-                .andExpect(jsonPath("$.name").value(testUser.getName()))
-                .andExpect(jsonPath("$.nickName").value(testUser.getNickName()))
-                .andExpect(jsonPath("$.role").value(testUser.getRole().getRoleName()));
-    }
-
-    @DisplayName("토큰에 포함된 이메일로 유저 조회 실패 테스트")
-    @Test
-    void findByToken_user_fail() throws Exception {
-        // Arrange
-        String testToken = jwtUtil.createAccessToken(testUser.getId(), "test@fail.com", testUser.getRole());
-
-        // Act & Assert
-        mockMvc.perform(get("/api/users")
-                        .cookie(new Cookie("Authorization", testToken))
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.status").value(false))
-                .andExpect(jsonPath("$.message").value("존재하지 않는 사용자입니다."));
-    }
-
-    @DisplayName("이메일 중복 확인 성공 테스트")
-    @Test
-    void findByEmail_user_success() throws Exception {
-        // Arrange
-        String email = "dooya@see.com";
-
-        // Act && Assert
-        mockMvc.perform(get("/api/users/check-email")
-                .param("email", email)
-                .contentType(MediaType.APPLICATION_JSON))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .with(user(loginUser)))
                 .andExpect(status().isOk());
+
+        // then
+        then(userQueryService).should().getUserByEmail("email");
     }
 
-    @DisplayName("이메일로 중복 확인 실패 테스트")
+    @DisplayName("/check-email 경로로 GET 요청 시 userValidator.validateDuplicateEmail(email) 호출 여부 검증")
     @Test
-    void findByEmail_user_fail() throws Exception {
-        // Arrange
-        String email = "test@see.com";
+    void get_WhenCalled_InvokeValidateDuplicateEmail() throws Exception {
+        // given
+        String email = "email";
 
-        // Act && Assert
+        // when
         mockMvc.perform(get("/api/users/check-email")
                         .param("email", email)
                         .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isConflict())
-                .andExpect(jsonPath("$.status").value(false))
-                .andExpect(jsonPath("$.message").value("이미 존재하는 사용자입니다."));
+                .andExpect(status().isOk());
+
+        // then
+        then(userValidator).should().validateDuplicateEmail(email);
     }
 
-    @DisplayName("유저 정보 수정 성공 테스트")
+    @DisplayName("PUT 요청 시 userUpdateService.updateNickName(email, command) 호출 여부 검증")
     @Test
-    void userNickName_update_success() throws Exception {
-        // Arrange
-        UserUpdateRequest request = nickNameUpdateRequest();
+    void put_WhenCalled_InvokeUpdateNickName() throws Exception {
+        // given
+        String email = "test@see.com";
+        LoginUser loginUser = new LoginUser(1L, "test@see.com", "USER");
+        UserUpdateRequest request = UserFixture.nickNameUpdateRequest();
+        UserUpdateCommand command = UserFixture.updateCommand();
 
-        // Act && Assert
+        given(userUpdateService.updateNickName(anyString(), any(UserUpdateCommand.class))).willReturn(UserFixture.testUserResult());
+
+        // when
         mockMvc.perform(put("/api/users")
                         .cookie(new Cookie("Authorization", testToken))
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.nickName").value(request.nickName()));
+                        .content(objectMapper.writeValueAsString(request))
+                        .with(user(loginUser)))
+                .andExpect(status().isOk());
+
+        // then
+        then(userUpdateService).should().updateNickName(email, command);
     }
 
-    @DisplayName("유저 정보 수정 실패 테스트")
+    @DisplayName("/password 경로로 PUT 요청 시 userUpdateService.updateUserPassword(email, command) 호출 여부 검증")
     @Test
-    void userNickName_update_fail() throws Exception {
-        // Arrange
-        UserUpdateRequest request = nickNameUpdateRequest();
-        String testToken = jwtUtil.createAccessToken(testUser.getId(), "test@fail.com", testUser.getRole());
+    void put_WhenCalled_InvokeUpdateUserPassword() throws Exception {
+        // given
+        String email = "test@see.com";
+        LoginUser loginUser = new LoginUser(1L, "test@see.com", "USER");
+        PasswordUpdateRequest request = UserFixture.passwordUpdateRequest();
+        PasswordUpdateCommand command = UserFixture.passwordUpdateCommand();
 
-        // Act & Assert
-        mockMvc.perform(put("/api/users")
-                        .cookie(new Cookie("Authorization", testToken))
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.status").value(false))
-                .andExpect(jsonPath("$.message").value("존재하지 않는 사용자입니다."));
-    }
+        given(userUpdateService.updatePassword(anyString(), any(PasswordUpdateCommand.class))).willReturn(UserFixture.passwordUpdateResult());
 
-    @DisplayName("유저 비밀번호 업데이트 성공 테스트")
-    @Test
-    void userPassword_Update_success() throws Exception {
-        // Arrange
-        PasswordUpdateRequest request = passwordUpdateRequest();
-
-        // Act & Assert
+        // when
         mockMvc.perform(put("/api/users/password")
                         .cookie(new Cookie("Authorization", testToken))
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.message").value("비밀번호가 성공적으로 변경되었습니다."));
-    }
+                        .content(objectMapper.writeValueAsString(request))
+                        .with(user(loginUser)))
+                .andExpect(status().isOk());
 
-    @DisplayName("유저 비밀번호 업데이트 실패 테스트")
-    @Test
-    void userPassword_Update_fail() throws Exception {
-        // Arrange
-        PasswordUpdateRequest request = passwordUpdateRequestFail();
-
-        // Act & Assert
-        mockMvc.perform(put("/api/users/password")
-                        .cookie(new Cookie("Authorization", testToken))
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.status").value(false))
-                .andExpect(jsonPath("$.message").value("비밀번호 정보가 일치하지 않습니다."));
-
+        // then
+        then(userUpdateService).should().updatePassword(email, command);
     }
 }

--- a/src/test/java/dooya/see/user/presentation/UserIntegrationTest.java
+++ b/src/test/java/dooya/see/user/presentation/UserIntegrationTest.java
@@ -1,0 +1,260 @@
+package dooya.see.user.presentation;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dooya.see.auth.util.JwtUtil;
+import dooya.see.common.UserFixture;
+import dooya.see.user.domain.User;
+import dooya.see.user.infrastructure.UserJpaRepository;
+import dooya.see.user.presentation.dto.PasswordUpdateRequest;
+import dooya.see.user.presentation.dto.UserSignUpRequest;
+import dooya.see.user.presentation.dto.UserUpdateRequest;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.stream.Stream;
+
+import static dooya.see.common.UserFixture.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Sql("classpath:init.sql")
+class UserIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private JwtUtil jwtUtil;
+
+    @Autowired
+    private UserJpaRepository userJpaRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    private User testUser;
+    private String testToken;
+
+    @BeforeEach
+    void setUp() {
+        testUser = userJpaRepository.save(UserFixture.mockUser(passwordEncoder));
+        testToken = jwtUtil.createAccessToken(testUser.getId(), testUser.getEmail(), testUser.getRole());
+    }
+
+    @DisplayName("유저 회원가입 성공 테스트")
+    @Test
+    void user_signUp_success() throws Exception {
+        UserSignUpRequest request = signUpRequest();
+
+        mockMvc.perform(post("/api/users")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").exists())
+                .andExpect(jsonPath("$.email").value(request.email()))
+                .andExpect(jsonPath("$.name").value(request.name()))
+                .andExpect(jsonPath("$.nickName").value(request.nickName()))
+                .andExpect(jsonPath("$.role").value("USER"));
+    }
+
+    @DisplayName("유저 회원가입 실패 테스트 - 개별 필드 유효성 검증")
+    @ParameterizedTest(name = "{index} => 필드 = {0}, 메시지 = {1}")
+    @MethodSource("invalidFieldProvider")
+    void user_signUp_fail_invalidField(UserSignUpRequest request, String field, String message) throws Exception {
+        mockMvc.perform(post("/api/users")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(false))
+                .andExpect(jsonPath("$.message").value("잘못된 요청입니다."))
+                .andExpect(jsonPath("$.validationErrors[0].field").value(field))
+                .andExpect(jsonPath("$.validationErrors[0].message").value(message));
+    }
+
+    @DisplayName("유저 회원가입 실패 테스트 - 모든 필드가 공란일때")
+    @Test
+    void user_signUp_fail_allFieldsInvalid() throws Exception {
+        UserSignUpRequest request = signUpRequest().toBuilder()
+                .email("")
+                .name("")
+                .password("")
+                .nickName("")
+                .build();
+
+        mockMvc.perform(post("/api/users")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(false))
+                .andExpect(jsonPath("$.message").value("잘못된 요청입니다."))
+                .andExpect(jsonPath("$.validationErrors[?(@.field=='email')].message").value("이메일은 비어 있을 수 없습니다"))
+                .andExpect(jsonPath("$.validationErrors[?(@.field=='name')].message").value("이름은 비어 있을 수 없습니다"))
+                .andExpect(jsonPath("$.validationErrors[?(@.field=='password')].message").value("비밀번호는 비어 있을 수 없습니다"))
+                .andExpect(jsonPath("$.validationErrors[?(@.field=='nickName')].message").value("닉네임은 비어 있을 수 없습니다"));
+    }
+
+    private static Stream<Arguments> invalidFieldProvider() {
+        return Stream.of(
+                Arguments.of(
+                        signUpRequest().toBuilder().email("").build(),
+                        "email", "이메일은 비어 있을 수 없습니다"
+                ),
+                Arguments.of(
+                        signUpRequest().toBuilder().name("").build(),
+                        "name", "이름은 비어 있을 수 없습니다"
+                ),
+                Arguments.of(
+                        signUpRequest().toBuilder().password("").build(),
+                        "password", "비밀번호는 비어 있을 수 없습니다"
+                ),
+                Arguments.of(
+                        signUpRequest().toBuilder().nickName("").build(),
+                        "nickName", "닉네임은 비어 있을 수 없습니다"
+                )
+        );
+    }
+
+    @DisplayName("토큰에 포함된 이메일로 유저 조회 성공테스트")
+    @Test
+    void findByToken_user_success() throws Exception {
+        // Act & Assert
+        mockMvc.perform(get("/api/users")
+                        .cookie(new Cookie("Authorization", testToken))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(testUser.getId()))
+                .andExpect(jsonPath("$.email").value(testUser.getEmail()))
+                .andExpect(jsonPath("$.name").value(testUser.getName()))
+                .andExpect(jsonPath("$.nickName").value(testUser.getNickName()))
+                .andExpect(jsonPath("$.role").value(testUser.getRole().getRoleName()));
+    }
+
+    @DisplayName("토큰에 포함된 이메일로 유저 조회 실패 테스트")
+    @Test
+    void findByToken_user_fail() throws Exception {
+        // Arrange
+        String testToken = jwtUtil.createAccessToken(testUser.getId(), "test@fail.com", testUser.getRole());
+
+        // Act & Assert
+        mockMvc.perform(get("/api/users")
+                        .cookie(new Cookie("Authorization", testToken))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.status").value(false))
+                .andExpect(jsonPath("$.message").value("존재하지 않는 사용자입니다."));
+    }
+
+    @DisplayName("이메일 중복 확인 성공 테스트")
+    @Test
+    void findByEmail_user_success() throws Exception {
+        // Arrange
+        String email = "dooya@see.com";
+
+        // Act && Assert
+        mockMvc.perform(get("/api/users/check-email")
+                .param("email", email)
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+    }
+
+    @DisplayName("이메일로 중복 확인 실패 테스트")
+    @Test
+    void findByEmail_user_fail() throws Exception {
+        // Arrange
+        String email = "test@see.com";
+
+        // Act && Assert
+        mockMvc.perform(get("/api/users/check-email")
+                        .param("email", email)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.status").value(false))
+                .andExpect(jsonPath("$.message").value("이미 존재하는 사용자입니다."));
+    }
+
+    @DisplayName("유저 정보 수정 성공 테스트")
+    @Test
+    void userNickName_update_success() throws Exception {
+        // Arrange
+        UserUpdateRequest request = nickNameUpdateRequest();
+
+        // Act && Assert
+        mockMvc.perform(put("/api/users")
+                        .cookie(new Cookie("Authorization", testToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.nickName").value(request.nickName()));
+    }
+
+    @DisplayName("유저 정보 수정 실패 테스트")
+    @Test
+    void userNickName_update_fail() throws Exception {
+        // Arrange
+        UserUpdateRequest request = nickNameUpdateRequest();
+        String testToken = jwtUtil.createAccessToken(testUser.getId(), "test@fail.com", testUser.getRole());
+
+        // Act & Assert
+        mockMvc.perform(put("/api/users")
+                        .cookie(new Cookie("Authorization", testToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.status").value(false))
+                .andExpect(jsonPath("$.message").value("존재하지 않는 사용자입니다."));
+    }
+
+    @DisplayName("유저 비밀번호 업데이트 성공 테스트")
+    @Test
+    void userPassword_Update_success() throws Exception {
+        // Arrange
+        PasswordUpdateRequest request = passwordUpdateRequest();
+
+        // Act & Assert
+        mockMvc.perform(put("/api/users/password")
+                        .cookie(new Cookie("Authorization", testToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("비밀번호가 성공적으로 변경되었습니다."));
+    }
+
+    @DisplayName("유저 비밀번호 업데이트 실패 테스트")
+    @Test
+    void userPassword_Update_fail() throws Exception {
+        // Arrange
+        PasswordUpdateRequest request = passwordUpdateRequestFail();
+
+        // Act & Assert
+        mockMvc.perform(put("/api/users/password")
+                        .cookie(new Cookie("Authorization", testToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(false))
+                .andExpect(jsonPath("$.message").value("비밀번호 정보가 일치하지 않습니다."));
+
+    }
+}


### PR DESCRIPTION
## 📌 Issue

<!-- 해결하려는 이슈 번호나 주제를 명확하게 적어주세요. -->

- closed #46

---

## 🧐 현재 상황

<!-- 현재 발생한 문제, 개선이 필요한 사항을 간략히 설명해주세요. -->

- 통합 테스트 이름을 명확하게 변경 및 Controller에 대한 단위테스트 필요

---

## 🎯 목표

<!-- 이슈를 통해 달성하고자 하는 목표를 설명해주세요. -->

- 테스트를 더 명확하게 확인하고 검증하도록 변경

---

## 🛠 작업 내용

- 작업 할 내용을 입력해주세요.

- [x] 통합테스트 이름 변경
- [x] Controller 단위 테스트 작성

---

## 🚀 기타 사항

<!-- 리뷰어가 추가적으로 알아야 할 사항이 있다면 기재해주세요. -->

- 추가적인 내용을 작성해주세요.(참고 자료, 협업 내용)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **테스트**
  - 사용자 관련 API의 통합 테스트가 추가되어 회원가입, 정보 조회, 이메일 중복 확인, 정보 및 비밀번호 수정 등 다양한 시나리오를 검증합니다.
  - 기존 컨트롤러 테스트가 서비스 호출 및 HTTP 상태 코드 위주의 단위 테스트로 리팩터링되었습니다.
  - 테스트 픽스처의 이메일 주소가 "dooya@see.com"으로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->