### PR TITLE
관리자 테스트 리팩터링 ControllerTest(통합테스트) -> IntegrationTest(통합테스트)로 명확하게 이름 변경 및 ControllerTest(단위테스트) 작성

### DIFF
--- a/src/test/java/dooya/see/admin/presentation/AdminControllerTest.java
+++ b/src/test/java/dooya/see/admin/presentation/AdminControllerTest.java
@@ -1,67 +1,47 @@
 package dooya.see.admin.presentation;
 
+import dooya.see.auth.config.SecurityConfig;
 import dooya.see.auth.util.JwtUtil;
-import dooya.see.common.AdminFixture;
-import dooya.see.common.UserFixture;
-import dooya.see.user.domain.Role;
-import dooya.see.user.domain.User;
-import dooya.see.user.infrastructure.UserJpaRepository;
-import jakarta.servlet.http.Cookie;
+import dooya.see.user.application.service.UserQueryService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.jdbc.Sql;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+import static org.mockito.BDDMockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@SpringBootTest
+@WebMvcTest(AdminController.class)
+@Import(SecurityConfig.class)
 @AutoConfigureMockMvc
-@ActiveProfiles("test")
-@Sql("classpath:init.sql")
 public class AdminControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
 
-    @Autowired
-    private UserJpaRepository userJpaRepository;
-
-    @Autowired
+    @MockitoBean
     private JwtUtil jwtUtil;
 
-    @DisplayName("유저 목록 조회 성공 테스트")
-    @Test
-    void admin_userSelect_success() throws Exception {
-        // Arrange
-        User testAdmin = userJpaRepository.save(AdminFixture.testAdmin());
-        String testToken = jwtUtil.createAccessToken(testAdmin.getId(), testAdmin.getEmail(), Role.valueOf(testAdmin.getRole().getRoleName()));
+    @MockitoBean
+    private UserQueryService userQueryService;
 
-        // Act & Assert
+    @DisplayName("GET 요청 시 userQueryService.getUsers() 호출 여부 검증")
+    @WithMockUser(roles = "ADMIN")
+    @Test
+    void get_WhenCalled_InvokesGetUsers() throws Exception {
+        // when
         mockMvc.perform(get("/api/admin")
-                        .cookie(new Cookie("Authorization", testToken))
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk());
-    }
 
-    @DisplayName("유저 목록 조회 실패 테스트")
-    @Test
-    void admin_userSelect_fail() throws Exception {
-        User testAdmin = userJpaRepository.save(UserFixture.testUser());
-        String testToken = jwtUtil.createAccessToken(testAdmin.getId(), testAdmin.getEmail(), Role.valueOf(testAdmin.getRole().getRoleName()));
-
-        // Act & Assert
-        mockMvc.perform(get("/api/admin")
-                        .cookie(new Cookie("Authorization", testToken))
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isForbidden())
-                .andExpect(jsonPath("$.status").value(false))
-                .andExpect(jsonPath("$.message").value("접근 권한이 없는 사용자입니다."));
+        // then
+        then(userQueryService).should().getUsers();
     }
 }

--- a/src/test/java/dooya/see/admin/presentation/AdminIntegrationTest.java
+++ b/src/test/java/dooya/see/admin/presentation/AdminIntegrationTest.java
@@ -53,12 +53,12 @@ public class AdminIntegrationTest {
     @DisplayName("유저 목록 조회 실패 테스트")
     @Test
     void admin_userSelect_fail() throws Exception {
-        User testAdmin = userJpaRepository.save(UserFixture.testUser());
-        String testToken = jwtUtil.createAccessToken(testAdmin.getId(), testAdmin.getEmail(), Role.valueOf(testAdmin.getRole().getRoleName()));
+        User regularUser = userJpaRepository.save(UserFixture.testUser());
+        String userToken = jwtUtil.createAccessToken(regularUser.getId(), regularUser.getEmail(), Role.valueOf(regularUser.getRole().getRoleName()));
 
         // Act & Assert
         mockMvc.perform(get("/api/admin")
-                        .cookie(new Cookie("Authorization", testToken))
+                        .cookie(new Cookie("Authorization", userToken))
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isForbidden())
                 .andExpect(jsonPath("$.status").value(false))

--- a/src/test/java/dooya/see/admin/presentation/AdminIntegrationTest.java
+++ b/src/test/java/dooya/see/admin/presentation/AdminIntegrationTest.java
@@ -1,0 +1,67 @@
+package dooya.see.admin.presentation;
+
+import dooya.see.auth.util.JwtUtil;
+import dooya.see.common.AdminFixture;
+import dooya.see.common.UserFixture;
+import dooya.see.user.domain.Role;
+import dooya.see.user.domain.User;
+import dooya.see.user.infrastructure.UserJpaRepository;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Sql("classpath:init.sql")
+public class AdminIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UserJpaRepository userJpaRepository;
+
+    @Autowired
+    private JwtUtil jwtUtil;
+
+    @DisplayName("유저 목록 조회 성공 테스트")
+    @Test
+    void admin_userSelect_success() throws Exception {
+        // Arrange
+        User testAdmin = userJpaRepository.save(AdminFixture.testAdmin());
+        String testToken = jwtUtil.createAccessToken(testAdmin.getId(), testAdmin.getEmail(), Role.valueOf(testAdmin.getRole().getRoleName()));
+
+        // Act & Assert
+        mockMvc.perform(get("/api/admin")
+                        .cookie(new Cookie("Authorization", testToken))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+    }
+
+    @DisplayName("유저 목록 조회 실패 테스트")
+    @Test
+    void admin_userSelect_fail() throws Exception {
+        User testAdmin = userJpaRepository.save(UserFixture.testUser());
+        String testToken = jwtUtil.createAccessToken(testAdmin.getId(), testAdmin.getEmail(), Role.valueOf(testAdmin.getRole().getRoleName()));
+
+        // Act & Assert
+        mockMvc.perform(get("/api/admin")
+                        .cookie(new Cookie("Authorization", testToken))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.status").value(false))
+                .andExpect(jsonPath("$.message").value("접근 권한이 없는 사용자입니다."));
+    }
+}


### PR DESCRIPTION
## 📌 Issue

<!-- 해결하려는 이슈 번호나 주제를 명확하게 적어주세요. -->

- closed #47

---

## 🧐 현재 상황

<!-- 현재 발생한 문제, 개선이 필요한 사항을 간략히 설명해주세요. -->

- 통합 테스트 이름을 명확하게 변경 및 Controller에 대한 단위테스트 필요

---

## 🎯 목표

<!-- 이슈를 통해 달성하고자 하는 목표를 설명해주세요. -->

- 테스트를 더 명확하게 확인하고 검증하도록 변경

---

## 🛠 작업 내용

- 작업 할 내용을 입력해주세요.

- [x] 통합 테스트 이름 변경
- [x] Controller 단위 테스트 작성

---

## 🚀 기타 사항

<!-- 리뷰어가 추가적으로 알아야 할 사항이 있다면 기재해주세요. -->

- 추가적인 내용을 작성해주세요.(참고 자료, 협업 내용)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **테스트**
  - 관리자 API 엔드포인트(`/api/admin`)에 대한 통합 테스트가 추가되어, 관리자와 비관리자 접근 시 각각의 응답 결과를 검증합니다.
  - 기존의 컨트롤러 테스트가 단위 테스트로 리팩토링되어, 인증 및 서비스 호출 여부만을 검증하도록 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->