### PR TITLE
로그인 테스트 리팩터링 ControllerTest(통합테스트) -> IntegrationTest(통합테스트)로 명확하게 이름 변경 및 ControllerTest(단위테스트) 작성

### DIFF
--- a/src/main/java/dooya/see/auth/application/dto/AuthApplicationMapper.java
+++ b/src/main/java/dooya/see/auth/application/dto/AuthApplicationMapper.java
@@ -1,0 +1,18 @@
+package dooya.see.auth.application.dto;
+
+import dooya.see.post.application.dto.PostResult;
+import dooya.see.post.domain.Post;
+import dooya.see.user.domain.User;
+
+public class AuthApplicationMapper {
+
+    public static LoginResult toResult(User user, String accessToken) {
+        return new LoginResult(
+                user.getId(),
+                user.getEmail(),
+                user.getName(),
+                user.getNickName(),
+                accessToken
+        );
+    }
+}

--- a/src/main/java/dooya/see/auth/application/dto/LoginResult.java
+++ b/src/main/java/dooya/see/auth/application/dto/LoginResult.java
@@ -16,10 +16,10 @@ import dooya.see.user.domain.User;
  * @author dooya
  */
 public record LoginResult(
-        User user,
+        Long id,
+        String email,
+        String name,
+        String nickName,
         String accessToken
 ) {
-    public static LoginResult of(User user, String accessToken) {
-        return new LoginResult(user, accessToken);
-    }
 }

--- a/src/main/java/dooya/see/auth/application/service/impl/AuthServiceImpl.java
+++ b/src/main/java/dooya/see/auth/application/service/impl/AuthServiceImpl.java
@@ -1,5 +1,6 @@
 package dooya.see.auth.application.service.impl;
 
+import dooya.see.auth.application.dto.AuthApplicationMapper;
 import dooya.see.auth.application.dto.LoginCommand;
 import dooya.see.auth.application.dto.LoginResult;
 import dooya.see.auth.application.service.AuthService;
@@ -22,6 +23,6 @@ public class AuthServiceImpl implements AuthService {
 
         String accessToken = jwtUtil.createAccessToken(user.getId(), user.getEmail(), user.getRole());
 
-        return LoginResult.of(user, accessToken);
+        return AuthApplicationMapper.toResult(user, accessToken);
     }
 }

--- a/src/main/java/dooya/see/auth/presentation/AuthController.java
+++ b/src/main/java/dooya/see/auth/presentation/AuthController.java
@@ -3,7 +3,7 @@ package dooya.see.auth.presentation;
 import dooya.see.auth.application.service.AuthService;
 import dooya.see.auth.application.dto.LoginCommand;
 import dooya.see.auth.application.dto.LoginResult;
-import dooya.see.auth.presentation.dto.AuthDtoMapper;
+import dooya.see.auth.presentation.dto.AuthPresentationMapper;
 import dooya.see.auth.presentation.dto.LoginRequest;
 import dooya.see.auth.presentation.dto.LoginResponse;
 import dooya.see.auth.util.CookieUtil;
@@ -45,13 +45,13 @@ public class AuthController {
 
     @PostMapping("/login")
     public ResponseEntity<LoginResponse> userLogin(@Valid @RequestBody LoginRequest request) {
-        LoginCommand command = AuthDtoMapper.toCommand(request);
+        LoginCommand command = AuthPresentationMapper.toCommand(request);
         LoginResult result = authService.login(command);
 
         ResponseCookie cookie = CookieUtil.createCookie(COOKIE_NAME, result.accessToken(), COOKIE_VALID_TIME);
 
         return ResponseEntity.ok()
                 .header(HttpHeaders.SET_COOKIE, cookie.toString())
-                .body(AuthDtoMapper.toResponse(result));
+                .body(AuthPresentationMapper.toResponse(result));
     }
 }

--- a/src/main/java/dooya/see/auth/presentation/dto/AuthPresentationMapper.java
+++ b/src/main/java/dooya/see/auth/presentation/dto/AuthPresentationMapper.java
@@ -2,7 +2,6 @@ package dooya.see.auth.presentation.dto;
 
 import dooya.see.auth.application.dto.LoginCommand;
 import dooya.see.auth.application.dto.LoginResult;
-import dooya.see.user.domain.User;
 
 /**
  * {@code AuthDtoMapper} 클래스는
@@ -19,7 +18,7 @@ import dooya.see.user.domain.User;
  *
  * @author dooya
  */
-public class AuthDtoMapper {
+public class AuthPresentationMapper {
 
     public static LoginCommand toCommand(LoginRequest request) {
         return new LoginCommand(
@@ -29,14 +28,12 @@ public class AuthDtoMapper {
     }
 
     public static LoginResponse toResponse(LoginResult result) {
-        User user = result.user();
-
         return new LoginResponse(
                 result.accessToken(),
-                user.getId(),
-                user.getEmail(),
-                user.getName(),
-                user.getNickName()
+                result.id(),
+                result.email(),
+                result.name(),
+                result.nickName()
         );
     }
 }

--- a/src/test/java/dooya/see/auth/application/AuthServiceTest.java
+++ b/src/test/java/dooya/see/auth/application/AuthServiceTest.java
@@ -57,7 +57,7 @@ public class AuthServiceTest {
         LoginResult result = authService.login(command);
 
         // Assert
-        assertThat(result.user().getEmail()).isEqualTo(testUser.getEmail());
+        assertThat(result.email()).isEqualTo(testUser.getEmail());
         assertThat(result.accessToken()).isEqualTo("mocked-jwt-token");
 
         then(authValidator).should(times(1)).validateEmailAndPassword(command.email(), command.password());

--- a/src/test/java/dooya/see/auth/presentation/AuthControllerTest.java
+++ b/src/test/java/dooya/see/auth/presentation/AuthControllerTest.java
@@ -1,36 +1,29 @@
 package dooya.see.auth.presentation;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import dooya.see.auth.application.dto.LoginCommand;
+import dooya.see.auth.application.service.AuthService;
+import dooya.see.auth.config.SecurityConfig;
 import dooya.see.auth.presentation.dto.LoginRequest;
-import dooya.see.common.UserFixture;
-import dooya.see.user.infrastructure.UserJpaRepository;
-import org.junit.jupiter.api.BeforeEach;
+import dooya.see.auth.util.JwtUtil;
+import dooya.see.common.AuthFixture;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
-import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
-import java.util.stream.Stream;
-
-import static dooya.see.common.AuthFixture.*;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@SpringBootTest
+@WebMvcTest(AuthController.class)
+@Import(SecurityConfig.class)
 @AutoConfigureMockMvc
-@ActiveProfiles("test")
-@Sql("classpath:init.sql")
 public class AuthControllerTest {
 
     @Autowired
@@ -39,59 +32,28 @@ public class AuthControllerTest {
     @Autowired
     private ObjectMapper objectMapper;
 
-    @Autowired
-    private UserJpaRepository userJpaRepository;
+    @MockitoBean
+    private AuthService authService;
 
-    @Autowired
-    private PasswordEncoder passwordEncoder;
+    @MockitoBean
+    private JwtUtil jwtUtil;
 
-    @BeforeEach
-    void setUp() {
-        userJpaRepository.save(UserFixture.mockUser(passwordEncoder));
-    }
-
-    @DisplayName("유저 로그인 성공 테스트")
+    @DisplayName("/login 경로로 POST 요청 시 authService.login(command) 호출 여부 검증")
     @Test
-    void user_login_success() throws Exception {
-        // Arrange
-        LoginRequest request = request();
+    void post_WhenCalled_InvokeLogin() throws Exception {
+        // given
+        LoginRequest request = AuthFixture.request();
+        LoginCommand command = AuthFixture.command();
 
-        // Act & Assert
+        given(authService.login(any(LoginCommand.class))).willReturn(AuthFixture.result());
+
+        // when
         mockMvc.perform(post("/api/auth/login")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.accessToken").exists())
-                .andExpect(result -> {
-                    String cookie = result.getResponse().getHeader("Set-Cookie");
-                    assertThat(cookie).contains("Authorization");
-                });
-    }
+                .andExpect(status().isOk());
 
-    @DisplayName("유저 로그인 실패 테스트 - 개별 필드 유효성 검증")
-    @ParameterizedTest(name = "{index} => 필드 = {0}, 메시지 = {1}")
-    @MethodSource("invalidFieldProvider")
-    void user_login_fail_invalidField(LoginRequest request, String field, String message) throws Exception {
-        mockMvc.perform(post("/api/auth/login")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.status").value(false))
-                .andExpect(jsonPath("$.message").value("잘못된 요청입니다."))
-                .andExpect(jsonPath("$.validationErrors[0].field").value(field))
-                .andExpect(jsonPath("$.validationErrors[0].message").value(message));
-    }
-
-    private static Stream<Arguments> invalidFieldProvider() {
-        return Stream.of(
-                Arguments.of(
-                        request().toBuilder().email("").build(),
-                        "email", "이메일은 비어 있을 수 없습니다"
-                ),
-                Arguments.of(
-                        request().toBuilder().password("").build(),
-                        "password", "비밀번호는 비어 있을 수 없습니다"
-                )
-        );
+        // then
+        then(authService).should().login(command);
     }
 }

--- a/src/test/java/dooya/see/auth/presentation/AuthIntegrationTest.java
+++ b/src/test/java/dooya/see/auth/presentation/AuthIntegrationTest.java
@@ -1,0 +1,97 @@
+package dooya.see.auth.presentation;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dooya.see.auth.presentation.dto.LoginRequest;
+import dooya.see.common.UserFixture;
+import dooya.see.user.infrastructure.UserJpaRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.stream.Stream;
+
+import static dooya.see.common.AuthFixture.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Sql("classpath:init.sql")
+public class AuthIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private UserJpaRepository userJpaRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @BeforeEach
+    void setUp() {
+        userJpaRepository.save(UserFixture.mockUser(passwordEncoder));
+    }
+
+    @DisplayName("유저 로그인 성공 테스트")
+    @Test
+    void user_login_success() throws Exception {
+        // Arrange
+        LoginRequest request = request();
+
+        // Act & Assert
+        mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.accessToken").exists())
+                .andExpect(result -> {
+                    String cookie = result.getResponse().getHeader("Set-Cookie");
+                    assertThat(cookie).contains("Authorization");
+                });
+    }
+
+    @DisplayName("유저 로그인 실패 테스트 - 개별 필드 유효성 검증")
+    @ParameterizedTest(name = "{index} => 필드 = {0}, 메시지 = {1}")
+    @MethodSource("invalidFieldProvider")
+    void user_login_fail_invalidField(LoginRequest request, String field, String message) throws Exception {
+        mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(false))
+                .andExpect(jsonPath("$.message").value("잘못된 요청입니다."))
+                .andExpect(jsonPath("$.validationErrors[0].field").value(field))
+                .andExpect(jsonPath("$.validationErrors[0].message").value(message));
+    }
+
+    private static Stream<Arguments> invalidFieldProvider() {
+        return Stream.of(
+                Arguments.of(
+                        request().toBuilder().email("").build(),
+                        "email", "이메일은 비어 있을 수 없습니다"
+                ),
+                Arguments.of(
+                        request().toBuilder().password("").build(),
+                        "password", "비밀번호는 비어 있을 수 없습니다"
+                )
+        );
+    }
+}

--- a/src/test/java/dooya/see/auth/presentation/AuthPresentationMapperTest.java
+++ b/src/test/java/dooya/see/auth/presentation/AuthPresentationMapperTest.java
@@ -8,12 +8,12 @@ import dooya.see.common.UserFixture;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import static dooya.see.auth.presentation.dto.AuthDtoMapper.*;
+import static dooya.see.auth.presentation.dto.AuthPresentationMapper.*;
 import static dooya.see.common.AuthFixture.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-public class AuthDtoMapperTest {
+public class AuthPresentationMapperTest {
 
     @DisplayName("LoginRequest를 LoginCommand로 정산 변환한다")
     @Test
@@ -35,7 +35,7 @@ public class AuthDtoMapperTest {
     @Test
     void convert_LoginResult_to_LoginResponse() {
         // Arrange
-        LoginResult result = new LoginResult(UserFixture.testUser(), "mocked-jwt-token");
+        LoginResult result = result();
 
         // Act
         LoginResponse response = toResponse(result);
@@ -43,10 +43,10 @@ public class AuthDtoMapperTest {
         // Assert
         assertAll(
                 () -> assertThat(response.accessToken()).isEqualTo("mocked-jwt-token"),
-                () -> assertThat(response.id()).isEqualTo(result.user().getId()),
-                () -> assertThat(response.email()).isEqualTo(result.user().getEmail()),
-                () -> assertThat(response.name()).isEqualTo(result.user().getName()),
-                () -> assertThat(response.nickName()).isEqualTo(result.user().getNickName())
+                () -> assertThat(response.id()).isEqualTo(result.id()),
+                () -> assertThat(response.email()).isEqualTo(result.email()),
+                () -> assertThat(response.name()).isEqualTo(result.name()),
+                () -> assertThat(response.nickName()).isEqualTo(result.nickName())
         );
     }
 }

--- a/src/test/java/dooya/see/common/AuthFixture.java
+++ b/src/test/java/dooya/see/common/AuthFixture.java
@@ -1,6 +1,7 @@
 package dooya.see.common;
 
 import dooya.see.auth.application.dto.LoginCommand;
+import dooya.see.auth.application.dto.LoginResult;
 import dooya.see.auth.presentation.dto.LoginRequest;
 
 public class AuthFixture {
@@ -11,5 +12,9 @@ public class AuthFixture {
 
     public static LoginCommand command() {
         return new LoginCommand("test@see.com", "testPassword");
+    }
+
+    public static LoginResult result() {
+        return new LoginResult(1L, "test@see.com", "testName", "testNickName", "mocked-jwt-token");
     }
 }


### PR DESCRIPTION
## 📌 Issue

<!-- 해결하려는 이슈 번호나 주제를 명확하게 적어주세요. -->

- closed #50

---

## 🧐 현재 상황

<!-- 현재 발생한 문제, 개선이 필요한 사항을 간략히 설명해주세요. -->

- 통합 테스트 이름을 명확하게 변경 및 Controller에 대한 단위테스트 필요

---

## 🎯 목표

<!-- 이슈를 통해 달성하고자 하는 목표를 설명해주세요. -->

- 테스트를 더 명확하게 확인하고 검증하도록 변경

---

## 🛠 작업 내용

- 작업 할 내용을 입력해주세요.

- [x] 통합테스트 이름 변경
- [x] Controller 단위 테스트 작성
- [x] 계층별 DTO 수정

---

## 🚀 기타 사항

<!-- 리뷰어가 추가적으로 알아야 할 사항이 있다면 기재해주세요. -->

- 추가적인 내용을 작성해주세요.(참고 자료, 협업 내용)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
	- 인증 통합 테스트가 추가되어 로그인 성공 및 실패(유효성 검사) 시나리오를 검증합니다.

- **버그 수정**
	- 로그인 결과에서 사용자 정보를 개별 필드(id, email, name, nickName)로 분리하여 반환합니다.

- **리팩터**
	- DTO 매퍼 클래스 및 테스트 클래스의 명칭과 구조가 일관성 있게 변경되었습니다.
	- 서비스 및 컨트롤러 내부의 매핑 로직이 전용 매퍼 클래스로 이동되었습니다.
	- 컨트롤러 테스트가 서비스 레이어와의 상호작용에 집중하는 슬라이스 테스트로 개선되었습니다.

- **테스트**
	- 통합 테스트 및 매퍼 테스트가 추가 및 개선되었습니다.
	- 테스트 픽스처에 로그인 결과 생성 메서드가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->