### PR TITLE
단일 게시글 조회 기능 추가

### DIFF
--- a/src/main/java/dooya/see/post/application/service/PostQueryService.java
+++ b/src/main/java/dooya/see/post/application/service/PostQueryService.java
@@ -6,4 +6,5 @@ import java.util.List;
 
 public interface PostQueryService {
     List<PostResult> getPosts();
+    PostResult getPost(Long id);
 }

--- a/src/main/java/dooya/see/post/application/service/impl/PostQueryServiceImpl.java
+++ b/src/main/java/dooya/see/post/application/service/impl/PostQueryServiceImpl.java
@@ -1,5 +1,7 @@
 package dooya.see.post.application.service.impl;
 
+import dooya.see.common.exception.CustomException;
+import dooya.see.common.exception.ErrorCode;
 import dooya.see.post.application.dto.PostApplicationMapper;
 import dooya.see.post.application.dto.PostResult;
 import dooya.see.post.application.service.PostQueryService;
@@ -23,5 +25,14 @@ public class PostQueryServiceImpl implements PostQueryService {
         List<Post> posts = postRepository.findAll();
 
         return PostApplicationMapper.toResults(posts);
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public PostResult getPost(Long id) {
+        Post post = postRepository.findById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
+
+        return PostApplicationMapper.toResult(post);
     }
 }

--- a/src/main/java/dooya/see/post/domain/PostRepository.java
+++ b/src/main/java/dooya/see/post/domain/PostRepository.java
@@ -1,8 +1,10 @@
 package dooya.see.post.domain;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface PostRepository {
     Post save(Post post);
     List<Post> findAll();
+    Optional<Post> findById(Long id);
 }

--- a/src/main/java/dooya/see/post/infrastructure/PostRepositoryImpl.java
+++ b/src/main/java/dooya/see/post/infrastructure/PostRepositoryImpl.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor
@@ -23,5 +24,10 @@ public class PostRepositoryImpl implements PostRepository {
     @Override
     public List<Post> findAll() {
         return postJpaRepository.findAll();
+    }
+
+    @Override
+    public Optional<Post> findById(Long id) {
+        return postJpaRepository.findById(id);
     }
 }

--- a/src/main/java/dooya/see/post/presentation/PostController.java
+++ b/src/main/java/dooya/see/post/presentation/PostController.java
@@ -5,6 +5,7 @@ import dooya.see.post.application.service.PostQueryService;
 import dooya.see.post.application.dto.PostCommand;
 import dooya.see.post.application.dto.PostResult;
 import dooya.see.post.application.service.PostCreateService;
+import dooya.see.post.domain.Post;
 import dooya.see.post.presentation.dto.PostPresentationMapper;
 import dooya.see.post.presentation.dto.PostRequest;
 import dooya.see.post.presentation.dto.PostResponse;
@@ -42,5 +43,12 @@ public class PostController {
         List<PostResult> posts = postQueryService.getPosts();
 
         return ResponseEntity.ok(PostPresentationMapper.toResponses(posts));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<PostResponse> getPost(@PathVariable Long id) {
+        PostResult result = postQueryService.getPost(id);
+
+        return ResponseEntity.ok(PostPresentationMapper.toResponse(result));
     }
 }

--- a/src/main/java/dooya/see/post/presentation/PostController.java
+++ b/src/main/java/dooya/see/post/presentation/PostController.java
@@ -8,7 +8,6 @@ import dooya.see.post.application.service.PostCreateService;
 import dooya.see.post.presentation.dto.PostPresentationMapper;
 import dooya.see.post.presentation.dto.PostRequest;
 import dooya.see.post.presentation.dto.PostResponse;
-import dooya.see.user.presentation.dto.UserPresentationMapper;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;

--- a/src/test/java/dooya/see/post/application/PostQueryServiceTest.java
+++ b/src/test/java/dooya/see/post/application/PostQueryServiceTest.java
@@ -1,6 +1,7 @@
 package dooya.see.post.application;
 
 import dooya.see.common.PostFixture;
+import dooya.see.common.exception.CustomException;
 import dooya.see.post.application.dto.PostResult;
 import dooya.see.post.application.service.impl.PostQueryServiceImpl;
 import dooya.see.post.domain.PostRepository;
@@ -12,8 +13,10 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.BDDMockito.*;
 
@@ -42,6 +45,37 @@ public class PostQueryServiceTest {
                 () -> assertThat(result.getFirst().nickName()).isEqualTo("testNickName"),
                 () -> assertThat(result.get(1).content()).contains("테스트용 게시물 내용 2입니다."),
                 () -> assertThat(result.get(2).id()).isNotNull()
+        );
+    }
+
+    @DisplayName("단일 게시글 조회 실패 테스트 - 게시글이 존재하지 않을 경우")
+    @Test
+    void getPost_shouldReturn_whenPostExistFail() {
+        // given
+        Long id = 1L;
+
+        // then
+        assertThatCode(() -> postQueryService.getPost(id))
+                .isInstanceOf(CustomException.class)
+                .hasMessage("게시글이 존재하지 않습니다.");
+    }
+
+    @DisplayName("단일 게시글 조회 성공 테스트")
+    @Test
+    void getPost_shouldReturn_whenPostExistSuccess() {
+        // given
+        Long id = 1L;
+        given(postRepository.findById(id)).willReturn(Optional.of(PostFixture.testPost()));
+
+        // when
+        PostResult result = postQueryService.getPost(id);
+
+        // then
+        assertAll(
+                () -> assertThat(result).isNotNull(),
+                () -> assertThat(result.nickName()).isEqualTo("testNickName"),
+                () -> assertThat(result.title()).isEqualTo("테스트용 게시글 제목"),
+                () -> assertThat(result.content()).isEqualTo("테스트용 게시물 내용입니다.")
         );
     }
 }

--- a/src/test/java/dooya/see/post/presentation/PostControllerTest.java
+++ b/src/test/java/dooya/see/post/presentation/PostControllerTest.java
@@ -70,12 +70,29 @@ public class PostControllerTest {
 
     @DisplayName("GET 요청 시 postQueryService.getPosts() 호출 여부 검증")
     @Test
-    void post_WhenCalled_InvokesGetPost() throws Exception {
+    void get_WhenCalled_InvokesGetPosts() throws Exception {
         // when
         mockMvc.perform(get("/api/post"))
                 .andExpect(status().isOk());
 
         // then
         then(postQueryService).should().getPosts();
+    }
+
+    @DisplayName("{id} 경로로 GET 요청 시 postQueryService.getPost(id) 호출 여부 검증")
+    @Test
+    void get_WhenCalled_InvokesGetPost() throws Exception {
+        // given
+        Long id = 1L;
+
+        given(postQueryService.getPost(anyLong())).willReturn(PostFixture.result());
+
+        // when
+        mockMvc.perform(get("/api/post/{id}", id)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+
+        // then
+        then(postQueryService).should().getPost(id);
     }
 }

--- a/src/test/java/dooya/see/post/presentation/PostIntegrationTest.java
+++ b/src/test/java/dooya/see/post/presentation/PostIntegrationTest.java
@@ -1,5 +1,6 @@
 package dooya.see.post.presentation;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dooya.see.auth.util.JwtUtil;
 import dooya.see.post.presentation.dto.PostRequest;
@@ -18,6 +19,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 
 import java.util.stream.Stream;
 
@@ -116,13 +118,50 @@ public class PostIntegrationTest {
                 .andExpect(jsonPath("$[0].content").exists());
     }
 
-    private void saveTestPost() throws Exception {
+    private long saveTestPost() throws Exception {
         PostRequest request = request();
 
-        mockMvc.perform(post("/api/post")
+        MvcResult result = mockMvc.perform(post("/api/post")
                         .cookie(new Cookie("Authorization", testToken))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isCreated());
+                .andExpect(status().isCreated())
+                .andReturn();
+
+        String responseBody = result.getResponse().getContentAsString();
+        JsonNode jsonNode = objectMapper.readTree(responseBody);
+
+        return jsonNode.get("id").asLong();
+    }
+
+    @DisplayName("단일 게시글 조회 성공 테스트")
+    @Test
+    void postId_GetPost_Success() throws Exception {
+        // Arrange
+        Long id = saveTestPost();
+
+        // Act && Assert
+        mockMvc.perform(get("/api/post/{id}", id)
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").exists())
+                .andExpect(jsonPath("$.nickName").exists())
+                .andExpect(jsonPath("$.title").exists())
+                .andExpect(jsonPath("$.content").exists());
+    }
+
+    @DisplayName("단일 게시글 조회 실패 테스트 - 게시글이 존재하지 않을 경우")
+    @Test
+    void postId_GetPost_Fail() throws Exception {
+        // Arrange
+        long id = saveTestPost();
+        id = 999L;
+
+        // Act && Assert
+        mockMvc.perform(get("/api/post/{id}", id)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.status").value(false))
+                .andExpect(jsonPath("$.message").value("게시글이 존재하지 않습니다."));
     }
 }


### PR DESCRIPTION
## 📌 Issue

<!-- 해결하려는 이슈 번호나 주제를 명확하게 적어주세요. -->

- closed #52

---

## 🧐 현재 상황

<!-- 현재 발생한 문제, 개선이 필요한 사항을 간략히 설명해주세요. -->

- 단일 게시글 조회 기능 추가

---

## 🎯 목표

<!-- 이슈를 통해 달성하고자 하는 목표를 설명해주세요. -->

- 단일 게시글 조회 가능 하도록 구현 및 테스트 검증

---

## 🛠 작업 내용

- 작업 할 내용을 입력해주세요.

- [x] 테스트 작성
- [x] 단일 게시글 조회 기능 구현

---

## 🚀 기타 사항

<!-- 리뷰어가 추가적으로 알아야 할 사항이 있다면 기재해주세요. -->

- 추가적인 내용을 작성해주세요.(참고 자료, 협업 내용)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 게시글 단건 조회 API가 추가되어, 특정 ID로 게시글을 조회할 수 있습니다.

- **버그 수정**
  - 불필요한 import가 제거되었습니다.

- **테스트**
  - 게시글 단건 조회 성공 및 실패 케이스에 대한 단위 테스트와 통합 테스트가 추가되었습니다.
  - 기존 테스트 메서드명이 더 명확하게 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->