### PR TITLE
모든 게시글 조회 페이징 기능 추가

### DIFF
--- a/src/main/java/dooya/see/post/application/dto/PostApplicationMapper.java
+++ b/src/main/java/dooya/see/post/application/dto/PostApplicationMapper.java
@@ -2,9 +2,7 @@ package dooya.see.post.application.dto;
 
 import dooya.see.post.domain.Post;
 import dooya.see.user.domain.User;
-
-import java.util.List;
-import java.util.stream.Collectors;
+import org.springframework.data.domain.Page;
 
 public class PostApplicationMapper {
 
@@ -25,7 +23,7 @@ public class PostApplicationMapper {
         );
     }
 
-    public static List<PostResult> toResults(List<Post> posts) {
-        return posts.stream().map(PostApplicationMapper::toResult).collect(Collectors.toList());
+    public static Page<PostResult> toResults(Page<Post> posts) {
+        return posts.map(PostApplicationMapper::toResult);
     }
 }

--- a/src/main/java/dooya/see/post/application/service/PostQueryService.java
+++ b/src/main/java/dooya/see/post/application/service/PostQueryService.java
@@ -1,10 +1,12 @@
 package dooya.see.post.application.service;
 
 import dooya.see.post.application.dto.PostResult;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
 public interface PostQueryService {
-    List<PostResult> getPosts();
+    Page<PostResult> getPosts(Pageable pageable);
     PostResult getPost(Long id);
 }

--- a/src/main/java/dooya/see/post/application/service/impl/PostQueryServiceImpl.java
+++ b/src/main/java/dooya/see/post/application/service/impl/PostQueryServiceImpl.java
@@ -8,10 +8,10 @@ import dooya.see.post.application.service.PostQueryService;
 import dooya.see.post.domain.Post;
 import dooya.see.post.domain.PostRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -21,8 +21,8 @@ public class PostQueryServiceImpl implements PostQueryService {
 
     @Transactional(readOnly = true)
     @Override
-    public List<PostResult> getPosts() {
-        List<Post> posts = postRepository.findAll();
+    public Page<PostResult> getPosts(Pageable pageable) {
+        Page<Post> posts = postRepository.findAll(pageable);
 
         return PostApplicationMapper.toResults(posts);
     }

--- a/src/main/java/dooya/see/post/domain/PostRepository.java
+++ b/src/main/java/dooya/see/post/domain/PostRepository.java
@@ -1,10 +1,12 @@
 package dooya.see.post.domain;
 
-import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
 import java.util.Optional;
 
 public interface PostRepository {
     Post save(Post post);
-    List<Post> findAll();
+    Page<Post> findAll(Pageable pageable);
     Optional<Post> findById(Long id);
 }

--- a/src/main/java/dooya/see/post/infrastructure/PostJpaRepository.java
+++ b/src/main/java/dooya/see/post/infrastructure/PostJpaRepository.java
@@ -1,10 +1,10 @@
 package dooya.see.post.infrastructure;
 
 import dooya.see.post.domain.Post;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
-
 public interface PostJpaRepository extends JpaRepository<Post, Long> {
-    List<Post> findAll();
+    Page<Post> findAll(Pageable pageable);
 }

--- a/src/main/java/dooya/see/post/infrastructure/PostRepositoryImpl.java
+++ b/src/main/java/dooya/see/post/infrastructure/PostRepositoryImpl.java
@@ -4,9 +4,10 @@ import dooya.see.post.domain.Post;
 import dooya.see.post.domain.PostRepository;
 import lombok.Builder;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -22,8 +23,8 @@ public class PostRepositoryImpl implements PostRepository {
     }
 
     @Override
-    public List<Post> findAll() {
-        return postJpaRepository.findAll();
+    public Page<Post> findAll(Pageable pageable) {
+        return postJpaRepository.findAll(pageable);
     }
 
     @Override

--- a/src/main/java/dooya/see/post/presentation/PostController.java
+++ b/src/main/java/dooya/see/post/presentation/PostController.java
@@ -11,6 +11,8 @@ import dooya.see.post.presentation.dto.PostRequest;
 import dooya.see.post.presentation.dto.PostResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -39,8 +41,8 @@ public class PostController {
     }
 
     @GetMapping
-    public ResponseEntity<List<PostResponse>> getPosts() {
-        List<PostResult> posts = postQueryService.getPosts();
+    public ResponseEntity<Page<PostResponse>> getPosts(Pageable pageable) {
+        Page<PostResult> posts = postQueryService.getPosts(pageable);
 
         return ResponseEntity.ok(PostPresentationMapper.toResponses(posts));
     }

--- a/src/main/java/dooya/see/post/presentation/dto/PostPresentationMapper.java
+++ b/src/main/java/dooya/see/post/presentation/dto/PostPresentationMapper.java
@@ -2,11 +2,7 @@ package dooya.see.post.presentation.dto;
 
 import dooya.see.post.application.dto.PostCommand;
 import dooya.see.post.application.dto.PostResult;
-import dooya.see.user.application.dto.UserResult;
-import dooya.see.user.presentation.dto.UserPresentationMapper;
-import dooya.see.user.presentation.dto.UserResponse;
-
-import java.util.List;
+import org.springframework.data.domain.Page;
 
 public class PostPresentationMapper {
 
@@ -26,9 +22,7 @@ public class PostPresentationMapper {
         );
     }
 
-    public static List<PostResponse> toResponses(List<PostResult> results) {
-        return results.stream()
-                .map(PostPresentationMapper::toResponse)
-                .toList();
+    public static Page<PostResponse> toResponses(Page<PostResult> results) {
+        return results.map(PostPresentationMapper::toResponse);
     }
 }

--- a/src/test/java/dooya/see/common/PostFixture.java
+++ b/src/test/java/dooya/see/common/PostFixture.java
@@ -4,6 +4,9 @@ import dooya.see.post.application.dto.PostCommand;
 import dooya.see.post.application.dto.PostResult;
 import dooya.see.post.domain.Post;
 import dooya.see.post.presentation.dto.PostRequest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 
 import java.util.List;
 
@@ -24,6 +27,15 @@ public class PostFixture {
                 "테스트용 게시글 제목",
                 "테스트용 게시물 내용입니다."
         );
+    }
+
+    public static Page<PostResult> pageResult() {
+        List<PostResult> content = List.of(
+                new PostResult(1L, "작성자1", "제목1", "내용1"),
+                new PostResult(2L, "작성자2", "제목2", "내용2")
+        );
+
+        return new PageImpl<>(content, PageRequest.of(0, 10), content.size());
     }
 
     public static Post testPost() {

--- a/src/test/java/dooya/see/post/application/PostQueryServiceTest.java
+++ b/src/test/java/dooya/see/post/application/PostQueryServiceTest.java
@@ -4,6 +4,7 @@ import dooya.see.common.PostFixture;
 import dooya.see.common.exception.CustomException;
 import dooya.see.post.application.dto.PostResult;
 import dooya.see.post.application.service.impl.PostQueryServiceImpl;
+import dooya.see.post.domain.Post;
 import dooya.see.post.domain.PostRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -11,6 +12,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 import java.util.Optional;
@@ -33,18 +38,18 @@ public class PostQueryServiceTest {
     @Test
     void getPosts_shouldReturnList_whenPostsExist() {
         // given
-        given(postRepository.findAll()).willReturn(PostFixture.testPosts());
+        Page<Post> page = new PageImpl<>(List.of(PostFixture.testPost()));
+        given(postRepository.findAll(any(Pageable.class))).willReturn(page);
 
         // when
-        List<PostResult> result = postQueryService.getPosts();
+        Page<PostResult> result = postQueryService.getPosts(PageRequest.of(0, 10));
 
         // then
         assertAll(
-                () -> assertThat(result).hasSize(3),
-                () -> assertThat(result.getFirst().title()).isEqualTo("테스트용 게시글 제목 1"),
-                () -> assertThat(result.getFirst().nickName()).isEqualTo("testNickName"),
-                () -> assertThat(result.get(1).content()).contains("테스트용 게시물 내용 2입니다."),
-                () -> assertThat(result.get(2).id()).isNotNull()
+                () -> assertThat(result).hasSize(1),
+                () -> assertThat(result.getContent().getFirst().title()).isEqualTo("테스트용 게시글 제목"),
+                () -> assertThat(result.getContent().getFirst().nickName()).isEqualTo("testNickName"),
+                () -> assertThat(result.getContent().getFirst().content()).contains("테스트용 게시물 내용입니다.")
         );
     }
 

--- a/src/test/java/dooya/see/post/presentation/PostControllerTest.java
+++ b/src/test/java/dooya/see/post/presentation/PostControllerTest.java
@@ -15,6 +15,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -71,12 +72,15 @@ public class PostControllerTest {
     @DisplayName("GET 요청 시 postQueryService.getPosts() 호출 여부 검증")
     @Test
     void get_WhenCalled_InvokesGetPosts() throws Exception {
+        // given
+        given(postQueryService.getPosts(any())).willReturn(PostFixture.pageResult());
+
         // when
         mockMvc.perform(get("/api/post"))
                 .andExpect(status().isOk());
 
         // then
-        then(postQueryService).should().getPosts();
+        then(postQueryService).should().getPosts(any(Pageable.class));
     }
 
     @DisplayName("{id} 경로로 GET 요청 시 postQueryService.getPost(id) 호출 여부 검증")

--- a/src/test/java/dooya/see/post/presentation/PostIntegrationTest.java
+++ b/src/test/java/dooya/see/post/presentation/PostIntegrationTest.java
@@ -110,12 +110,14 @@ public class PostIntegrationTest {
 
         // Act && Assert
         mockMvc.perform(get("/api/post")
+                        .param("page", "0")
+                        .param("size", "10")
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$[0].id").exists())
-                .andExpect(jsonPath("$[0].nickName").exists())
-                .andExpect(jsonPath("$[0].title").exists())
-                .andExpect(jsonPath("$[0].content").exists());
+                .andExpect(jsonPath("$.content[0].id").exists())
+                .andExpect(jsonPath("$.content[0].nickName").exists())
+                .andExpect(jsonPath("$.content[0].title").exists())
+                .andExpect(jsonPath("$.content[0].content").exists());
     }
 
     private long saveTestPost() throws Exception {


### PR DESCRIPTION
## 📌 Issue

<!-- 해결하려는 이슈 번호나 주제를 명확하게 적어주세요. -->

- closed #54

---

## 🧐 현재 상황

<!-- 현재 발생한 문제, 개선이 필요한 사항을 간략히 설명해주세요. -->

- List로 불러온 게시글을 Page로 불러오도록 수정

---

## 🎯 목표

<!-- 이슈를 통해 달성하고자 하는 목표를 설명해주세요. -->

- Page로 게시글을 불러오도록 수정

---

## 🛠 작업 내용

- 작업 할 내용을 입력해주세요.

- [x] List -> Page로 변경
- [x] 테스트 수정

---

## 🚀 기타 사항

<!-- 리뷰어가 추가적으로 알아야 할 사항이 있다면 기재해주세요. -->

- 추가적인 내용을 작성해주세요.(참고 자료, 협업 내용)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - 게시글 목록 조회 엔드포인트에 페이지네이션(페이징) 기능이 추가되었습니다. 이제 페이지 및 크기 파라미터로 원하는 범위의 게시글을 조회할 수 있습니다.

- **Bug Fixes**
  - 게시글 목록 조회 시 반환 구조가 페이지 형태로 변경되어, 대량 데이터 조회 시 성능이 개선되었습니다.

- **Tests**
  - 게시글 목록 조회 및 컨트롤러 테스트가 페이지네이션 구조에 맞게 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->