### PR TITLE
공통 날짜 필드 관리를 위한 BaseEntity 도입

### DIFF
--- a/src/main/java/dooya/see/SeeApplication.java
+++ b/src/main/java/dooya/see/SeeApplication.java
@@ -2,8 +2,10 @@ package dooya.see;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class SeeApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/dooya/see/common/base/BaseEntity.java
+++ b/src/main/java/dooya/see/common/base/BaseEntity.java
@@ -1,0 +1,28 @@
+package dooya.see.common.base;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseEntity {
+
+    @CreatedDate
+    @Column(name = "created_at" , updatable = false)
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm")
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm")
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/dooya/see/post/domain/Post.java
+++ b/src/main/java/dooya/see/post/domain/Post.java
@@ -1,5 +1,6 @@
 package dooya.see.post.domain;
 
+import dooya.see.common.base.BaseEntity;
 import dooya.see.user.domain.Role;
 import dooya.see.user.domain.User;
 import jakarta.persistence.*;
@@ -13,7 +14,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
-public class Post {
+public class Post extends BaseEntity {
 
     @Id
     @GeneratedValue

--- a/src/main/java/dooya/see/user/domain/User.java
+++ b/src/main/java/dooya/see/user/domain/User.java
@@ -1,5 +1,6 @@
 package dooya.see.user.domain;
 
+import dooya.see.common.base.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -27,7 +28,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
-public class User {
+public class User extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/test/java/dooya/see/admin/presentation/AdminControllerTest.java
+++ b/src/test/java/dooya/see/admin/presentation/AdminControllerTest.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -31,6 +32,9 @@ public class AdminControllerTest {
 
     @MockitoBean
     private UserQueryService userQueryService;
+
+    @MockitoBean
+    private JpaMetamodelMappingContext jpaMetamodelMappingContext;
 
     @DisplayName("GET 요청 시 userQueryService.getUsers() 호출 여부 검증")
     @WithMockUser(roles = "ADMIN")

--- a/src/test/java/dooya/see/auth/presentation/AuthControllerTest.java
+++ b/src/test/java/dooya/see/auth/presentation/AuthControllerTest.java
@@ -13,6 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -37,6 +38,9 @@ public class AuthControllerTest {
 
     @MockitoBean
     private JwtUtil jwtUtil;
+
+    @MockitoBean
+    private JpaMetamodelMappingContext jpaMetamodelMappingContext;
 
     @DisplayName("/login 경로로 POST 요청 시 authService.login(command) 호출 여부 검증")
     @Test

--- a/src/test/java/dooya/see/post/presentation/PostControllerTest.java
+++ b/src/test/java/dooya/see/post/presentation/PostControllerTest.java
@@ -16,6 +16,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -46,6 +47,9 @@ public class PostControllerTest {
 
     @MockitoBean
     private PostCreateService postCreateService;
+
+    @MockitoBean
+    private JpaMetamodelMappingContext jpaMetamodelMappingContext;
 
     @DisplayName("POST 요청 시 postCreateService.createPost() 호출 여부 검증")
     @Test

--- a/src/test/java/dooya/see/user/presentation/UserControllerTest.java
+++ b/src/test/java/dooya/see/user/presentation/UserControllerTest.java
@@ -24,6 +24,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -64,6 +65,9 @@ public class UserControllerTest {
 
     @MockitoBean
     private PasswordEncoder passwordEncoder;
+
+    @MockitoBean
+    private JpaMetamodelMappingContext jpaMetamodelMappingContext;
 
     private String testToken;
 


### PR DESCRIPTION
## 📌 Issue

<!-- 해결하려는 이슈 번호나 주제를 명확하게 적어주세요. -->

- closed #56

---

## 🧐 현재 상황

<!-- 현재 발생한 문제, 개선이 필요한 사항을 간략히 설명해주세요. -->

- 엔티티에 값이 수정 되었을때 변경 등 날짜가 없음

---

## 🎯 목표

<!-- 이슈를 통해 달성하고자 하는 목표를 설명해주세요. -->

- 각 엔티티들이 BaseEntity를 상속 받아 날짜 필드를 포함하도록 수정

---

## 🛠 작업 내용

- 작업 할 내용을 입력해주세요.

- [x] BaseEntity 생성
- [x] 엔티티에 BaseEntity 상속
- [x] Controller 단위테스트에 JPA 설정 추가

---

## 🚀 기타 사항

<!-- 리뷰어가 추가적으로 알아야 할 사항이 있다면 기재해주세요. -->

- 추가적인 내용을 작성해주세요.(참고 자료, 협업 내용)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 게시글 및 사용자 정보에 생성일과 수정일 자동 기록 기능이 추가되었습니다.

- **테스트**
  - 테스트 환경에서 JPA 메타모델 관련 의존성이 추가되어 테스트 안정성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->