### PR TITLE
게시물 Response DTO 필드에 날짜 필드 추가

### DIFF
--- a/src/main/java/dooya/see/post/application/dto/PostApplicationMapper.java
+++ b/src/main/java/dooya/see/post/application/dto/PostApplicationMapper.java
@@ -19,7 +19,9 @@ public class PostApplicationMapper {
                 post.getId(),
                 post.getUser().getNickName(),
                 post.getTitle(),
-                post.getContent()
+                post.getContent(),
+                post.getCreatedAt(),
+                post.getUpdatedAt()
         );
     }
 

--- a/src/main/java/dooya/see/post/application/dto/PostResult.java
+++ b/src/main/java/dooya/see/post/application/dto/PostResult.java
@@ -1,9 +1,13 @@
 package dooya.see.post.application.dto;
 
+import java.time.LocalDateTime;
+
 public record PostResult(
         Long id,
         String nickName,
         String title,
-        String content
+        String content,
+        LocalDateTime createdDate,
+        LocalDateTime updatedDate
 ) {
 }

--- a/src/main/java/dooya/see/post/presentation/dto/PostPresentationMapper.java
+++ b/src/main/java/dooya/see/post/presentation/dto/PostPresentationMapper.java
@@ -18,7 +18,9 @@ public class PostPresentationMapper {
                 result.id(),
                 result.nickName(),
                 result.title(),
-                result.content()
+                result.content(),
+                result.createdDate(),
+                result.updatedDate()
         );
     }
 

--- a/src/main/java/dooya/see/post/presentation/dto/PostResponse.java
+++ b/src/main/java/dooya/see/post/presentation/dto/PostResponse.java
@@ -1,9 +1,13 @@
 package dooya.see.post.presentation.dto;
 
+import java.time.LocalDateTime;
+
 public record PostResponse(
         Long id,
         String nickName,
         String title,
-        String content
+        String content,
+        LocalDateTime createdDate,
+        LocalDateTime updatedDate
 ) {
 }

--- a/src/test/java/dooya/see/common/PostFixture.java
+++ b/src/test/java/dooya/see/common/PostFixture.java
@@ -8,6 +8,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public class PostFixture {
@@ -25,14 +26,20 @@ public class PostFixture {
                 1L,
                 "testNickName",
                 "테스트용 게시글 제목",
-                "테스트용 게시물 내용입니다."
+                "테스트용 게시물 내용입니다.",
+                LocalDateTime.of(2025, 5, 25, 14, 30),
+                LocalDateTime.of(2025, 5, 25, 15, 30)
         );
     }
 
     public static Page<PostResult> pageResult() {
         List<PostResult> content = List.of(
-                new PostResult(1L, "작성자1", "제목1", "내용1"),
-                new PostResult(2L, "작성자2", "제목2", "내용2")
+                new PostResult(1L, "작성자1", "제목1", "내용1",
+                        LocalDateTime.of(2025, 5, 24, 10, 30),
+                        LocalDateTime.of(2025, 5, 25, 12, 0)),
+                new PostResult(2L, "작성자2", "제목2", "내용2",
+                        LocalDateTime.of(2025, 5, 24, 11, 0),
+                        LocalDateTime.of(2025, 5, 24, 11, 0))
         );
 
         return new PageImpl<>(content, PageRequest.of(0, 10), content.size());

--- a/src/test/java/dooya/see/post/presentation/PostIntegrationTest.java
+++ b/src/test/java/dooya/see/post/presentation/PostIntegrationTest.java
@@ -118,7 +118,8 @@ public class PostIntegrationTest {
                 .andExpect(jsonPath("$.content[0].nickName").exists())
                 .andExpect(jsonPath("$.content[0].title").exists())
                 .andExpect(jsonPath("$.content[0].content").exists())
-                .andExpect(jsonPath("$.content[0].createdDate").exists());
+                .andExpect(jsonPath("$.content[0].createdDate").exists())
+                .andExpect(jsonPath("$.content[0].updatedDate").exists());
     }
 
     private long saveTestPost() throws Exception {
@@ -151,7 +152,8 @@ public class PostIntegrationTest {
                 .andExpect(jsonPath("$.nickName").exists())
                 .andExpect(jsonPath("$.title").exists())
                 .andExpect(jsonPath("$.content").exists())
-                .andExpect(jsonPath("$.createdDate").exists());
+                .andExpect(jsonPath("$.createdDate").exists())
+                .andExpect(jsonPath("$.updatedDate").exists());
     }
 
     @DisplayName("단일 게시글 조회 실패 테스트 - 게시글이 존재하지 않을 경우")

--- a/src/test/java/dooya/see/post/presentation/PostIntegrationTest.java
+++ b/src/test/java/dooya/see/post/presentation/PostIntegrationTest.java
@@ -117,7 +117,8 @@ public class PostIntegrationTest {
                 .andExpect(jsonPath("$.content[0].id").exists())
                 .andExpect(jsonPath("$.content[0].nickName").exists())
                 .andExpect(jsonPath("$.content[0].title").exists())
-                .andExpect(jsonPath("$.content[0].content").exists());
+                .andExpect(jsonPath("$.content[0].content").exists())
+                .andExpect(jsonPath("$.content[0].createdDate").exists());
     }
 
     private long saveTestPost() throws Exception {
@@ -149,7 +150,8 @@ public class PostIntegrationTest {
                 .andExpect(jsonPath("$.id").exists())
                 .andExpect(jsonPath("$.nickName").exists())
                 .andExpect(jsonPath("$.title").exists())
-                .andExpect(jsonPath("$.content").exists());
+                .andExpect(jsonPath("$.content").exists())
+                .andExpect(jsonPath("$.createdDate").exists());
     }
 
     @DisplayName("단일 게시글 조회 실패 테스트 - 게시글이 존재하지 않을 경우")

--- a/src/test/java/dooya/see/post/presentation/PostPresentationMapperTest.java
+++ b/src/test/java/dooya/see/post/presentation/PostPresentationMapperTest.java
@@ -46,7 +46,8 @@ public class PostPresentationMapperTest {
                 () -> assertThat(response.id()).isEqualTo(result.id()),
                 () -> assertThat(response.nickName()).isEqualTo(result.nickName()),
                 () -> assertThat(response.title()).isEqualTo(result.title()),
-                () -> assertThat(response.content()).isEqualTo(result.content())
+                () -> assertThat(response.createdDate()).isEqualTo(result.createdDate()),
+                () -> assertThat(response.updatedDate()).isEqualTo(result.updatedDate())
         );
     }
 }


### PR DESCRIPTION
## 📌 Issue

<!-- 해결하려는 이슈 번호나 주제를 명확하게 적어주세요. -->

- closed #58

---

## 🧐 현재 상황

<!-- 현재 발생한 문제, 개선이 필요한 사항을 간략히 설명해주세요. -->

- 게시물 응답 DTO에 날짜 응답이 없어 게시글에 대한 정보 확인 불편함

---

## 🎯 목표

<!-- 이슈를 통해 달성하고자 하는 목표를 설명해주세요. -->

- 게시물 응답에 날짜 포함하여 확인하기 쉽게 변경

---

## 🛠 작업 내용

- 작업 할 내용을 입력해주세요.

- [x] Response DTO 필드 추가
- [x] 테스트 검증

---

## 🚀 기타 사항

<!-- 리뷰어가 추가적으로 알아야 할 사항이 있다면 기재해주세요. -->

- 추가적인 내용을 작성해주세요.(참고 자료, 협업 내용)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 게시글 조회 시 생성일(createdDate)과 수정일(updatedDate) 정보가 추가로 제공됩니다.

- **버그 수정**
    - 게시글 API 응답 및 관련 테스트에서 생성일과 수정일 필드가 정상적으로 반환되고 검증되도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->