### PR TITLE
회원가입 진행시 유저 기본 프로필 설정되도록 기능 추가

### DIFF
--- a/src/main/java/dooya/see/common/config/UserProfileProperties.java
+++ b/src/main/java/dooya/see/common/config/UserProfileProperties.java
@@ -1,0 +1,15 @@
+package dooya.see.common.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "user.profile")
+@Getter
+@Setter
+public class UserProfileProperties {
+
+    private String defaultImageUrl;
+}

--- a/src/main/java/dooya/see/user/application/dto/UserApplicationMapper.java
+++ b/src/main/java/dooya/see/user/application/dto/UserApplicationMapper.java
@@ -42,6 +42,7 @@ public class UserApplicationMapper {
                 user.getEmail(),
                 user.getName(),
                 user.getNickName(),
+                user.getProfileImageUrl(),
                 user.getRole()
         );
     }

--- a/src/main/java/dooya/see/user/application/dto/UserApplicationMapper.java
+++ b/src/main/java/dooya/see/user/application/dto/UserApplicationMapper.java
@@ -25,12 +25,13 @@ import java.util.stream.Collectors;
  */
 public class UserApplicationMapper {
 
-    public static User toEntity(UserSignUpCommand command, PasswordEncoder passwordEncoder) {
+    public static User toEntity(UserSignUpCommand command, PasswordEncoder passwordEncoder, String defaultImageUrl) {
         return User.signUpUser(
                 command.email(),
                 command.name(),
                 passwordEncoder.encode(command.password()),
                 command.nickName(),
+                defaultImageUrl,
                 Role.of("USER")
         );
     }

--- a/src/main/java/dooya/see/user/application/dto/UserResult.java
+++ b/src/main/java/dooya/see/user/application/dto/UserResult.java
@@ -19,6 +19,7 @@ public record UserResult(
         String email,
         String name,
         String nickName,
+        String profileImageUrl,
         Role role
 ) {
 }

--- a/src/main/java/dooya/see/user/application/service/impl/UserSignUpServiceImpl.java
+++ b/src/main/java/dooya/see/user/application/service/impl/UserSignUpServiceImpl.java
@@ -1,5 +1,6 @@
 package dooya.see.user.application.service.impl;
 
+import dooya.see.common.config.UserProfileProperties;
 import dooya.see.user.application.dto.UserApplicationMapper;
 import dooya.see.user.application.dto.UserResult;
 import dooya.see.user.application.dto.UserSignUpCommand;
@@ -19,12 +20,13 @@ public class UserSignUpServiceImpl implements UserSignUpService {
     private final UserRepository userRepository;
     private final UserValidator userValidator;
     private final PasswordEncoder passwordEncoder;
+    private final UserProfileProperties userProfileProperties;
 
     @Transactional
     @Override
     public UserResult userSignUp(UserSignUpCommand command) {
         userValidator.validateDuplicateEmail(command.email());
-        User user = UserApplicationMapper.toEntity(command, passwordEncoder);
+        User user = UserApplicationMapper.toEntity(command, passwordEncoder, userProfileProperties.getDefaultImageUrl());
         userRepository.save(user);
 
         return UserApplicationMapper.toResult(user);

--- a/src/main/java/dooya/see/user/domain/User.java
+++ b/src/main/java/dooya/see/user/domain/User.java
@@ -47,13 +47,13 @@ public class User extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private Role role;
 
-    public static User signUpUser(String email, String name, String password, String nickName, Role role) {
+    public static User signUpUser(String email, String name, String password, String nickName, String defaultImageUrl, Role role) {
         return User.builder()
                 .email(email)
                 .name(name)
                 .password(password)
                 .nickName(nickName)
-                .profileImageUrl(null)
+                .profileImageUrl(defaultImageUrl)
                 .role(role)
                 .build();
     }

--- a/src/main/java/dooya/see/user/presentation/dto/UserPresentationMapper.java
+++ b/src/main/java/dooya/see/user/presentation/dto/UserPresentationMapper.java
@@ -36,6 +36,7 @@ public class UserPresentationMapper {
                 userResult.email(),
                 userResult.name(),
                 userResult.nickName(),
+                userResult.profileImageUrl(),
                 userResult.role()
         );
     }

--- a/src/main/java/dooya/see/user/presentation/dto/UserSignUpResponse.java
+++ b/src/main/java/dooya/see/user/presentation/dto/UserSignUpResponse.java
@@ -19,6 +19,7 @@ public record UserSignUpResponse(
         String email,
         String name,
         String nickName,
+        String profileImageUrl,
         Role role
 ) {
 }

--- a/src/test/java/dooya/see/common/UserFixture.java
+++ b/src/test/java/dooya/see/common/UserFixture.java
@@ -11,12 +11,6 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 public class UserFixture {
 
-    private static String defaultImageUrl = "https://fake-s3//profile.jpeg";
-
-    public static void setDefaultImageUrl(String url) {
-        defaultImageUrl = url;
-    }
-
     public static UserSignUpRequest signUpRequest() {
         return new UserSignUpRequest("dooya@see.com", "testName", "testPassword", "testNickName");
     }
@@ -51,7 +45,7 @@ public class UserFixture {
                 command.name(),
                 command.password(),
                 command.nickName(),
-                defaultImageUrl,
+                "https://fake-s3/profile.jpeg",
                 Role.of("USER")
         );
         ReflectionTestUtils.setField(testUser, "id", 1L);
@@ -69,7 +63,7 @@ public class UserFixture {
     }
 
     public static UserResult testUserResult() {
-        return new UserResult(1L, "dooya@see.com", "testName", "testNickName", Role.of("USER"));
+        return new UserResult(1L, "dooya@see.com", "testName", "testNickName", "https://fake-s3/profile.jpeg", Role.of("USER"));
     }
 
     public static PasswordUpdateResult passwordUpdateResult() {

--- a/src/test/java/dooya/see/common/UserFixture.java
+++ b/src/test/java/dooya/see/common/UserFixture.java
@@ -11,6 +11,12 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 public class UserFixture {
 
+    private static String defaultImageUrl = "https://fake-s3//profile.jpeg";
+
+    public static void setDefaultImageUrl(String url) {
+        defaultImageUrl = url;
+    }
+
     public static UserSignUpRequest signUpRequest() {
         return new UserSignUpRequest("dooya@see.com", "testName", "testPassword", "testNickName");
     }
@@ -45,6 +51,7 @@ public class UserFixture {
                 command.name(),
                 command.password(),
                 command.nickName(),
+                defaultImageUrl,
                 Role.of("USER")
         );
         ReflectionTestUtils.setField(testUser, "id", 1L);

--- a/src/test/java/dooya/see/user/application/UserSignUpServiceTest.java
+++ b/src/test/java/dooya/see/user/application/UserSignUpServiceTest.java
@@ -54,6 +54,7 @@ public class UserSignUpServiceTest {
 
         doNothing().when(userValidator).validateDuplicateEmail(command.email());
         given(passwordEncoder.encode(command.password())).willReturn(testUser.getPassword());
+        given(userProfileProperties.getDefaultImageUrl()).willReturn("default-image-url");
         given(userRepository.save(any(User.class))).willReturn(testUser);
 
         // Act
@@ -65,6 +66,7 @@ public class UserSignUpServiceTest {
                 () -> assertThat(result.email()).isEqualTo(command.email()),
                 () -> assertThat(result.name()).isEqualTo(command.name()),
                 () -> assertThat(result.nickName()).isEqualTo(command.nickName()),
+                () -> assertThat(result.profileImageUrl()).isNotNull(),
                 () -> assertThat(result.role()).isEqualTo(Role.USER)
         );
 

--- a/src/test/java/dooya/see/user/application/UserSignUpServiceTest.java
+++ b/src/test/java/dooya/see/user/application/UserSignUpServiceTest.java
@@ -1,5 +1,6 @@
 package dooya.see.user.application;
 
+import dooya.see.common.config.UserProfileProperties;
 import dooya.see.common.exception.CustomException;
 import dooya.see.common.exception.ErrorCode;
 import dooya.see.user.application.dto.UserResult;
@@ -10,6 +11,7 @@ import dooya.see.user.domain.Role;
 import dooya.see.user.domain.User;
 import dooya.see.user.domain.UserRepository;
 import dooya.see.common.UserFixture;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -40,6 +42,14 @@ public class UserSignUpServiceTest {
 
     @Mock
     private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private UserProfileProperties userProfileProperties;
+
+    @BeforeEach
+    void setUp() {
+        UserFixture.setDefaultImageUrl("https://fake-s3/profile.jpeg");
+    }
 
     @DisplayName("유저 회원가입 성공 단위테스트")
     @Test

--- a/src/test/java/dooya/see/user/application/UserSignUpServiceTest.java
+++ b/src/test/java/dooya/see/user/application/UserSignUpServiceTest.java
@@ -11,7 +11,6 @@ import dooya.see.user.domain.Role;
 import dooya.see.user.domain.User;
 import dooya.see.user.domain.UserRepository;
 import dooya.see.common.UserFixture;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -45,11 +44,6 @@ public class UserSignUpServiceTest {
 
     @Mock
     private UserProfileProperties userProfileProperties;
-
-    @BeforeEach
-    void setUp() {
-        UserFixture.setDefaultImageUrl("https://fake-s3/profile.jpeg");
-    }
 
     @DisplayName("유저 회원가입 성공 단위테스트")
     @Test

--- a/src/test/java/dooya/see/user/presentation/UserIntegrationTest.java
+++ b/src/test/java/dooya/see/user/presentation/UserIntegrationTest.java
@@ -76,6 +76,7 @@ class UserIntegrationTest {
                 .andExpect(jsonPath("$.email").value(request.email()))
                 .andExpect(jsonPath("$.name").value(request.name()))
                 .andExpect(jsonPath("$.nickName").value(request.nickName()))
+                .andExpect(jsonPath("$.profileImageUrl").isNotEmpty())
                 .andExpect(jsonPath("$.role").value("USER"));
     }
 


### PR DESCRIPTION
## 📌 Issue

<!-- 해결하려는 이슈 번호나 주제를 명확하게 적어주세요. -->

- closed #62

---

## 🧐 현재 상황

<!-- 현재 발생한 문제, 개선이 필요한 사항을 간략히 설명해주세요. -->

- 회원가입 진행시 유저 기본 프로필이 null로 저장중이였음

---

## 🎯 목표

<!-- 이슈를 통해 달성하고자 하는 목표를 설명해주세요. -->

- 회원가입 진행시 유저 기본 프로필 이미지가 저장되도록 수정

---

## 🛠 작업 내용

- 작업 할 내용을 입력해주세요.

- [x] 기본 프로필 이미지 설정 클래스 작성
- [x] 서비스 및 DTO 수정
- [x] 테스트 검증

---

## 🚀 기타 사항

<!-- 리뷰어가 추가적으로 알아야 할 사항이 있다면 기재해주세요. -->

- 추가적인 내용을 작성해주세요.(참고 자료, 협업 내용)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 회원 가입 시 기본 프로필 이미지 URL이 자동으로 할당되어 반환됩니다.
    - 회원 가입 응답 및 사용자 정보에 프로필 이미지 URL이 추가되었습니다.

- **버그 수정**
    - 회원 가입 성공 시 프로필 이미지 URL이 정상적으로 포함되는지 테스트가 보강되었습니다.

- **테스트**
    - 테스트 유틸 및 통합 테스트에 프로필 이미지 URL 관련 검증이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->