### PR TITLE
유저 프로필 이미지 수정 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,7 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
     // AWS S3
-    implementation 'com.amazonaws:aws-java-sdk-s3:1.12.782'
+    implementation 'com.amazonaws:aws-java-sdk-s3:1.12.783'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,9 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+    // AWS S3
+    implementation 'com.amazonaws:aws-java-sdk-s3:1.12.782'
 }
 
 tasks.named('test') {

--- a/src/main/java/dooya/see/common/config/S3Config.java
+++ b/src/main/java/dooya/see/common/config/S3Config.java
@@ -1,0 +1,31 @@
+package dooya.see.common.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3 amazonS3() {
+        BasicAWSCredentials awsCreds = new BasicAWSCredentials(accessKey, secretKey);
+        return AmazonS3ClientBuilder.standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(awsCreds))
+                .build();
+    }
+}

--- a/src/main/java/dooya/see/common/s3/S3Uploader.java
+++ b/src/main/java/dooya/see/common/s3/S3Uploader.java
@@ -1,0 +1,38 @@
+package dooya.see.common.s3;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class S3Uploader {
+
+    private final AmazonS3 amazonS3;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    public String upload(MultipartFile file, String dirName) {
+        String fileName = dirName + "/" + UUID.randomUUID() + "_" + file.getOriginalFilename();
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentLength(file.getSize());
+        metadata.setContentType(file.getContentType());
+        metadata.setContentDisposition("inline");
+
+        try (InputStream inputStream = file.getInputStream()) {
+            amazonS3.putObject(bucket, fileName, inputStream, metadata);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        return amazonS3.getUrl(bucket, fileName).toString();
+    }
+}

--- a/src/main/java/dooya/see/user/application/service/UserUpdateService.java
+++ b/src/main/java/dooya/see/user/application/service/UserUpdateService.java
@@ -4,6 +4,7 @@ import dooya.see.user.application.dto.PasswordUpdateCommand;
 import dooya.see.user.application.dto.PasswordUpdateResult;
 import dooya.see.user.application.dto.UserResult;
 import dooya.see.user.application.dto.UserUpdateCommand;
+import org.springframework.web.multipart.MultipartFile;
 
 /**
  * {@code UserUpdateService}는 사용자 정보 업데이트 기능을 제공하는
@@ -34,4 +35,6 @@ public interface UserUpdateService {
      * @return 업데이트된 메시지 정보를 담은 {@link PasswordUpdateResult}
      */
     PasswordUpdateResult updatePassword(String email, PasswordUpdateCommand command);
+
+    UserResult updateProfileImage(String email, MultipartFile profileImage);
 }

--- a/src/main/java/dooya/see/user/application/service/impl/UserUpdateServiceImpl.java
+++ b/src/main/java/dooya/see/user/application/service/impl/UserUpdateServiceImpl.java
@@ -2,6 +2,7 @@ package dooya.see.user.application.service.impl;
 
 import dooya.see.common.exception.CustomException;
 import dooya.see.common.exception.ErrorCode;
+import dooya.see.common.s3.S3Uploader;
 import dooya.see.user.application.dto.PasswordUpdateCommand;
 import dooya.see.user.application.dto.PasswordUpdateResult;
 import dooya.see.user.application.dto.UserResult;
@@ -13,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import static dooya.see.user.application.dto.UserApplicationMapper.*;
 
@@ -22,6 +24,7 @@ public class UserUpdateServiceImpl implements UserUpdateService {
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final S3Uploader s3Uploader;
 
     @Transactional
     @Override
@@ -42,5 +45,18 @@ public class UserUpdateServiceImpl implements UserUpdateService {
         user.updatePassword(passwordEncoder.encode(command.newPassword()));
 
         return new PasswordUpdateResult("비밀번호가 성공적으로 변경되었습니다.");
+    }
+
+    @Transactional
+    @Override
+    public UserResult updateProfileImage(String email, MultipartFile profileImage) {
+        String uploadImageUrl = s3Uploader.upload(profileImage, "profile");
+
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        user.updateProfileImage(uploadImageUrl);
+
+        return toResult(user);
     }
 }

--- a/src/main/java/dooya/see/user/domain/User.java
+++ b/src/main/java/dooya/see/user/domain/User.java
@@ -65,4 +65,8 @@ public class User extends BaseEntity {
     public void updatePassword(String newPassword) {
         this.password = newPassword;
     }
+
+    public void updateProfileImage(String uploadImageUrl) {
+        this.profileImageUrl = uploadImageUrl;
+    }
 }

--- a/src/main/java/dooya/see/user/presentation/UserController.java
+++ b/src/main/java/dooya/see/user/presentation/UserController.java
@@ -9,9 +9,11 @@ import dooya.see.user.application.service.UserValidator;
 import dooya.see.user.presentation.dto.*;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.net.URI;
 
@@ -86,5 +88,14 @@ public class UserController {
         PasswordUpdateResult result = userUpdateService.updatePassword(email, command);
 
         return ResponseEntity.ok().body(toPasswordUpdateResponse(result));
+    }
+
+    @PatchMapping(value = "/profile-image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<UserResponse> updateProfileImage(@AuthenticationPrincipal LoginUser loginUser,
+                                                           @RequestPart MultipartFile profileImage) {
+        String email = loginUser.getUsername();
+        UserResult result = userUpdateService.updateProfileImage(email, profileImage);
+
+        return ResponseEntity.ok().body(toResponse(result));
     }
 }

--- a/src/main/java/dooya/see/user/presentation/dto/UserPresentationMapper.java
+++ b/src/main/java/dooya/see/user/presentation/dto/UserPresentationMapper.java
@@ -66,6 +66,7 @@ public class UserPresentationMapper {
                 result.email(),
                 result.name(),
                 result.nickName(),
+                result.profileImageUrl(),
                 result.role()
         );
     }

--- a/src/main/java/dooya/see/user/presentation/dto/UserResponse.java
+++ b/src/main/java/dooya/see/user/presentation/dto/UserResponse.java
@@ -17,6 +17,7 @@ public record UserResponse(
         String email,
         String name,
         String nickName,
+        String profileImageUrl,
         Role role
 ) {
 }

--- a/src/test/java/dooya/see/user/application/UserUpdateServiceTest.java
+++ b/src/test/java/dooya/see/user/application/UserUpdateServiceTest.java
@@ -2,6 +2,7 @@ package dooya.see.user.application;
 
 import dooya.see.common.exception.CustomException;
 import dooya.see.common.exception.ErrorCode;
+import dooya.see.common.s3.S3Uploader;
 import dooya.see.user.application.dto.PasswordUpdateCommand;
 import dooya.see.user.application.dto.PasswordUpdateResult;
 import dooya.see.user.application.dto.UserResult;
@@ -16,6 +17,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.Optional;
 
@@ -24,8 +26,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.*;
 
 
 @ExtendWith(MockitoExtension.class)
@@ -39,6 +40,9 @@ public class UserUpdateServiceTest {
 
     @Mock
     private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private S3Uploader s3Uploader;
 
     private final User testUser = testUser();
 
@@ -102,6 +106,45 @@ public class UserUpdateServiceTest {
         assertThatCode(() -> userUpdateService.updatePassword(testUser.getEmail(), command))
                 .isInstanceOf(CustomException.class)
                 .hasMessageContaining("비밀번호 정보가 일치하지 않습니다.");
+
+        then(userRepository).should(times(1)).findByEmail(testUser.getEmail());
+    }
+
+    @DisplayName("유저 프로필 이미지 업데이트 성공 테스트")
+    @Test
+    void user_profileUpdate_success() {
+        // Arrange
+        String email = "test@example.com";
+        String expectedImageUrl = "https://s3.amazon.com/profile/image.png";
+
+        MultipartFile mockFile = mock(MultipartFile.class);
+        User testUser = testUser();
+
+        given(s3Uploader.upload(mockFile, "profile")).willReturn(expectedImageUrl);
+        given(userRepository.findByEmail(email)).willReturn(Optional.of(testUser));
+
+        // Act
+        UserResult result = userUpdateService.updateProfileImage(email, mockFile);
+
+        // Assert
+        assertThat(result.profileImageUrl()).isEqualTo(expectedImageUrl);
+        assertThat(testUser.getProfileImageUrl()).isEqualTo(expectedImageUrl);
+
+        then(s3Uploader).should(times(1)).upload(mockFile, "profile");
+        then(userRepository).should(times(1)).findByEmail(email);
+    }
+
+    @DisplayName("유저 프로필 이미지 업데이트 실패 테스트 - 유저가 존재하지 않음")
+    @Test
+    void user_profileUpdate_fail() {
+        // Arrange
+        MultipartFile mockFile = mock(MultipartFile.class);
+        doThrow(new CustomException(ErrorCode.USER_NOT_FOUND)).when(userRepository).findByEmail(testUser.getEmail());
+
+        // Act & Assert
+        assertThatCode(() -> userUpdateService.updateProfileImage(testUser.getEmail(), mockFile))
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining("존재하지 않는 사용자입니다.");
 
         then(userRepository).should(times(1)).findByEmail(testUser.getEmail());
     }

--- a/src/test/java/dooya/see/user/presentation/UserControllerTest.java
+++ b/src/test/java/dooya/see/user/presentation/UserControllerTest.java
@@ -26,6 +26,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -175,5 +176,37 @@ public class UserControllerTest {
 
         // then
         then(userUpdateService).should().updatePassword(email, command);
+    }
+
+    @DisplayName("/profile-image 경로로 PATCH 요청 시 userUpdateService.updateProfileImage(email, profileImage) 호출 여부 검증")
+    @Test
+    void patch_WhenCalled_InvokeUpdateProfileImage() throws Exception {
+        // given
+        String email = "test@see.com";
+        LoginUser loginUser = new LoginUser(1L, "test@see.com", "USER");
+
+        MockMultipartFile mockImage = new MockMultipartFile(
+                "profileImage",
+                "profile.jpg",
+                "image/jpeg",
+                "fake-image-content".getBytes()
+        );
+
+        given(userUpdateService.updateProfileImage(anyString(), any())).willReturn(UserFixture.testUserResult());
+
+        // when
+        mockMvc.perform(multipart("/api/users/profile-image")
+                        .file(mockImage)
+                        .cookie(new Cookie("Authorization", testToken))
+                        .with(user(loginUser))
+                        .with(request -> {
+                            request.setMethod("PATCH");
+                            return request;
+                        })
+                )
+                .andExpect(status().isOk());
+
+        // then
+        then(userUpdateService).should().updateProfileImage(email, mockImage);
     }
 }

--- a/src/test/java/dooya/see/user/presentation/UserIntegrationTest.java
+++ b/src/test/java/dooya/see/user/presentation/UserIntegrationTest.java
@@ -19,6 +19,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
@@ -27,9 +28,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import java.util.stream.Stream;
 
 import static dooya.see.common.UserFixture.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -257,5 +256,29 @@ class UserIntegrationTest {
                 .andExpect(jsonPath("$.status").value(false))
                 .andExpect(jsonPath("$.message").value("비밀번호 정보가 일치하지 않습니다."));
 
+    }
+
+    @DisplayName("유저 프로필 이미지 업데이트 성공 테스트")
+    @Test
+    void userProfile_Update_Success() throws Exception {
+        // Arrange
+        MockMultipartFile mockImage = new MockMultipartFile(
+                "profileImage",
+                "profile.jpg",
+                "image/jpeg",
+                "fake-image-content".getBytes()
+        );
+
+        // Act && Assert
+        mockMvc.perform(multipart("/api/users/profile-image")
+                        .file(mockImage)
+                        .cookie(new Cookie("Authorization", testToken))
+                        .with(request -> {
+                            request.setMethod("PATCH");
+                            return request;
+                        })
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.profileImageUrl").isNotEmpty());
     }
 }


### PR DESCRIPTION
## 📌 Issue

<!-- 해결하려는 이슈 번호나 주제를 명확하게 적어주세요. -->

- closed #64

---

## 🧐 현재 상황

<!-- 현재 발생한 문제, 개선이 필요한 사항을 간략히 설명해주세요. -->

- 기본으로 저장된 유저 이미지를 업데이트 할수 있게 해야됨

---

## 🎯 목표

<!-- 이슈를 통해 달성하고자 하는 목표를 설명해주세요. -->

- 유저가 프로필 이미지를 업데이트 할수 있도록 함

---

## 🛠 작업 내용

- 작업 할 내용을 입력해주세요.

- [x] S3 의존성 추가
- [x] S3 설정 클래스 구현
- [x] 테스트 작성
- [x] Controller 메서드 구현
- [x] Service 구현

---

## 🚀 기타 사항

<!-- 리뷰어가 추가적으로 알아야 할 사항이 있다면 기재해주세요. -->

- 추가적인 내용을 작성해주세요.(참고 자료, 협업 내용)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 사용자가 프로필 이미지를 S3에 업로드하여 변경할 수 있는 기능이 추가되었습니다.
  - 프로필 이미지 URL이 사용자 정보 응답에 포함됩니다.

- **버그 수정**
  - 해당 없음

- **테스트**
  - 프로필 이미지 업데이트 성공 및 실패 시나리오에 대한 단위 테스트와 통합 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->