### PR TITLE
유저 닉네임 업데이트 API 리팩터링

### DIFF
--- a/src/main/java/dooya/see/user/application/dto/NickNameUpdateCommand.java
+++ b/src/main/java/dooya/see/user/application/dto/NickNameUpdateCommand.java
@@ -11,7 +11,7 @@ package dooya.see.user.application.dto;
  *
  * @author dooya
  */
-public record UserUpdateCommand(
+public record NickNameUpdateCommand(
         String nickName
 ) {
 }

--- a/src/main/java/dooya/see/user/application/service/UserUpdateService.java
+++ b/src/main/java/dooya/see/user/application/service/UserUpdateService.java
@@ -3,14 +3,14 @@ package dooya.see.user.application.service;
 import dooya.see.user.application.dto.PasswordUpdateCommand;
 import dooya.see.user.application.dto.PasswordUpdateResult;
 import dooya.see.user.application.dto.UserResult;
-import dooya.see.user.application.dto.UserUpdateCommand;
+import dooya.see.user.application.dto.NickNameUpdateCommand;
 import org.springframework.web.multipart.MultipartFile;
 
 /**
  * {@code UserUpdateService}는 사용자 정보 업데이트 기능을 제공하는
  * 애플리케이션 서비스 인터페이스입니다.
  *
- * <p>특정 사용자의 이메일을 기준으로 {@link UserUpdateCommand}를 받아
+ * <p>특정 사용자의 이메일을 기준으로 {@link NickNameUpdateCommand}를 받아
  * 사용자 정보를 수정하고, 수정된 결과를 {@link UserResult}로 반환합니다.
  *
  * <p>비즈니스 로직은 구현체에서 처리하며, 인터페이스는 기능 명세 역할을 합니다.
@@ -22,10 +22,10 @@ public interface UserUpdateService {
      * 지정된 이메일을 가진 사용자의 닉네임을 업데이트합니다.
      *
      * @param email 닉네임을 변경할 사용자의 이메일
-     * @param command 변경할 닉네임 정보가 담긴 {@link UserUpdateCommand}
+     * @param command 변경할 닉네임 정보가 담긴 {@link NickNameUpdateCommand}
      * @return 업데이트된 사용자 정보를 담은 {@link UserResult}
      */
-    UserResult updateNickName(String email, UserUpdateCommand command);
+    UserResult updateNickName(String email, NickNameUpdateCommand command);
 
     /**
      * 지정된 이메일을 가진 사용자의 비밀번호를 업데이트합니다.

--- a/src/main/java/dooya/see/user/application/service/impl/UserUpdateServiceImpl.java
+++ b/src/main/java/dooya/see/user/application/service/impl/UserUpdateServiceImpl.java
@@ -6,7 +6,7 @@ import dooya.see.common.s3.S3Uploader;
 import dooya.see.user.application.dto.PasswordUpdateCommand;
 import dooya.see.user.application.dto.PasswordUpdateResult;
 import dooya.see.user.application.dto.UserResult;
-import dooya.see.user.application.dto.UserUpdateCommand;
+import dooya.see.user.application.dto.NickNameUpdateCommand;
 import dooya.see.user.application.service.UserUpdateService;
 import dooya.see.user.domain.User;
 import dooya.see.user.domain.UserRepository;
@@ -28,7 +28,7 @@ public class UserUpdateServiceImpl implements UserUpdateService {
 
     @Transactional
     @Override
-    public UserResult updateNickName(String email, UserUpdateCommand command) {
+    public UserResult updateNickName(String email, NickNameUpdateCommand command) {
         User user = userRepository.findByEmail(email)
                         .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
         user.updateNickName(command.nickName());

--- a/src/main/java/dooya/see/user/presentation/UserController.java
+++ b/src/main/java/dooya/see/user/presentation/UserController.java
@@ -109,14 +109,14 @@ public class UserController {
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "닉네임 변경 성공",
-                    content = @Content(schema = @Schema(implementation = UserUpdateResponse.class))),
+                    content = @Content(schema = @Schema(implementation = NickNameUpdateResponse.class))),
             @ApiResponse(responseCode = "404", description = "사용자 정보를 찾을 수 없음", content = @Content)
     })
     @PutMapping("/nick-name")
-    public ResponseEntity<UserUpdateResponse> updateUserNickName(@AuthenticationPrincipal LoginUser loginUser,
-                                                                 @Valid @RequestBody UserUpdateRequest request) {
+    public ResponseEntity<NickNameUpdateResponse> updateUserNickName(@AuthenticationPrincipal LoginUser loginUser,
+                                                                     @Valid @RequestBody NickNameUpdateRequest request) {
         String email = loginUser.getUsername();
-        UserUpdateCommand command = toUpdateCommand(request);
+        NickNameUpdateCommand command = toUpdateCommand(request);
         UserResult result = userUpdateService.updateNickName(email, command);
 
         return ResponseEntity.ok().body(toUpdateResponse(result));

--- a/src/main/java/dooya/see/user/presentation/UserController.java
+++ b/src/main/java/dooya/see/user/presentation/UserController.java
@@ -112,7 +112,7 @@ public class UserController {
                     content = @Content(schema = @Schema(implementation = UserUpdateResponse.class))),
             @ApiResponse(responseCode = "404", description = "사용자 정보를 찾을 수 없음", content = @Content)
     })
-    @PutMapping
+    @PutMapping("/nick-name")
     public ResponseEntity<UserUpdateResponse> updateUserNickName(@AuthenticationPrincipal LoginUser loginUser,
                                                                  @Valid @RequestBody UserUpdateRequest request) {
         String email = loginUser.getUsername();

--- a/src/main/java/dooya/see/user/presentation/dto/NickNameUpdateRequest.java
+++ b/src/main/java/dooya/see/user/presentation/dto/NickNameUpdateRequest.java
@@ -12,7 +12,7 @@ import lombok.Builder;
  * @author dooya
  */
 @Builder
-public record UserUpdateRequest(
+public record NickNameUpdateRequest(
         String nickName
 ) {
 }

--- a/src/main/java/dooya/see/user/presentation/dto/NickNameUpdateResponse.java
+++ b/src/main/java/dooya/see/user/presentation/dto/NickNameUpdateResponse.java
@@ -11,7 +11,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
  *
  * @author dooya
  */
-public record UserUpdateResponse(
+public record NickNameUpdateResponse(
 
         @Schema(description = "업데이트 된 사용자 닉네임", example = "See")
         String nickName

--- a/src/main/java/dooya/see/user/presentation/dto/UserPresentationMapper.java
+++ b/src/main/java/dooya/see/user/presentation/dto/UserPresentationMapper.java
@@ -41,12 +41,12 @@ public class UserPresentationMapper {
         );
     }
 
-    public static UserUpdateCommand toUpdateCommand(UserUpdateRequest request) {
-        return new UserUpdateCommand(request.nickName());
+    public static NickNameUpdateCommand toUpdateCommand(NickNameUpdateRequest request) {
+        return new NickNameUpdateCommand(request.nickName());
     }
 
-    public static UserUpdateResponse toUpdateResponse(UserResult userResult) {
-        return new UserUpdateResponse(userResult.nickName());
+    public static NickNameUpdateResponse toUpdateResponse(UserResult userResult) {
+        return new NickNameUpdateResponse(userResult.nickName());
     }
 
     public static PasswordUpdateCommand toPasswordUpdateCommand(PasswordUpdateRequest request) {

--- a/src/test/java/dooya/see/common/UserFixture.java
+++ b/src/test/java/dooya/see/common/UserFixture.java
@@ -5,7 +5,7 @@ import dooya.see.user.presentation.dto.PasswordUpdateRequest;
 import dooya.see.user.presentation.dto.UserSignUpRequest;
 import dooya.see.user.domain.Role;
 import dooya.see.user.domain.User;
-import dooya.see.user.presentation.dto.UserUpdateRequest;
+import dooya.see.user.presentation.dto.NickNameUpdateRequest;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -15,8 +15,8 @@ public class UserFixture {
         return new UserSignUpRequest("dooya@see.com", "testName", "testPassword", "testNickName");
     }
 
-    public static UserUpdateRequest nickNameUpdateRequest() {
-        return new UserUpdateRequest("updateNickName");
+    public static NickNameUpdateRequest nickNameUpdateRequest() {
+        return new NickNameUpdateRequest("updateNickName");
     }
 
     public static PasswordUpdateRequest passwordUpdateRequest() {
@@ -31,8 +31,8 @@ public class UserFixture {
         return new UserSignUpCommand("dooya@see.com", "testName", "testPassword", "testNickName");
     }
 
-    public static UserUpdateCommand updateCommand() {
-        return new UserUpdateCommand("updateNickName");
+    public static NickNameUpdateCommand updateCommand() {
+        return new NickNameUpdateCommand("updateNickName");
     }
 
     public static PasswordUpdateCommand passwordUpdateCommand() {

--- a/src/test/java/dooya/see/user/application/UserUpdateServiceTest.java
+++ b/src/test/java/dooya/see/user/application/UserUpdateServiceTest.java
@@ -6,7 +6,7 @@ import dooya.see.common.s3.S3Uploader;
 import dooya.see.user.application.dto.PasswordUpdateCommand;
 import dooya.see.user.application.dto.PasswordUpdateResult;
 import dooya.see.user.application.dto.UserResult;
-import dooya.see.user.application.dto.UserUpdateCommand;
+import dooya.see.user.application.dto.NickNameUpdateCommand;
 import dooya.see.user.application.service.impl.UserUpdateServiceImpl;
 import dooya.see.user.domain.User;
 import dooya.see.user.domain.UserRepository;
@@ -50,7 +50,7 @@ public class UserUpdateServiceTest {
     @Test
     void user_nickNameUpdate_success() {
         // Arrange
-        UserUpdateCommand command = updateCommand();
+        NickNameUpdateCommand command = updateCommand();
 
         given(userRepository.findByEmail(testUser.getEmail())).willReturn(Optional.of(testUser));
 

--- a/src/test/java/dooya/see/user/presentation/UserControllerTest.java
+++ b/src/test/java/dooya/see/user/presentation/UserControllerTest.java
@@ -144,7 +144,7 @@ public class UserControllerTest {
         given(userUpdateService.updateNickName(anyString(), any(UserUpdateCommand.class))).willReturn(UserFixture.testUserResult());
 
         // when
-        mockMvc.perform(put("/api/users")
+        mockMvc.perform(put("/api/users/nick-name")
                         .cookie(new Cookie("Authorization", testToken))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request))

--- a/src/test/java/dooya/see/user/presentation/UserControllerTest.java
+++ b/src/test/java/dooya/see/user/presentation/UserControllerTest.java
@@ -7,7 +7,7 @@ import dooya.see.auth.util.JwtUtil;
 import dooya.see.common.UserFixture;
 import dooya.see.user.application.dto.PasswordUpdateCommand;
 import dooya.see.user.application.dto.UserSignUpCommand;
-import dooya.see.user.application.dto.UserUpdateCommand;
+import dooya.see.user.application.dto.NickNameUpdateCommand;
 import dooya.see.user.application.service.UserQueryService;
 import dooya.see.user.application.service.UserSignUpService;
 import dooya.see.user.application.service.UserUpdateService;
@@ -15,7 +15,7 @@ import dooya.see.user.application.service.UserValidator;
 import dooya.see.user.domain.User;
 import dooya.see.user.presentation.dto.PasswordUpdateRequest;
 import dooya.see.user.presentation.dto.UserSignUpRequest;
-import dooya.see.user.presentation.dto.UserUpdateRequest;
+import dooya.see.user.presentation.dto.NickNameUpdateRequest;
 import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -138,10 +138,10 @@ public class UserControllerTest {
         // given
         String email = "test@see.com";
         LoginUser loginUser = new LoginUser(1L, "test@see.com", "USER");
-        UserUpdateRequest request = UserFixture.nickNameUpdateRequest();
-        UserUpdateCommand command = UserFixture.updateCommand();
+        NickNameUpdateRequest request = UserFixture.nickNameUpdateRequest();
+        NickNameUpdateCommand command = UserFixture.updateCommand();
 
-        given(userUpdateService.updateNickName(anyString(), any(UserUpdateCommand.class))).willReturn(UserFixture.testUserResult());
+        given(userUpdateService.updateNickName(anyString(), any(NickNameUpdateCommand.class))).willReturn(UserFixture.testUserResult());
 
         // when
         mockMvc.perform(put("/api/users/nick-name")

--- a/src/test/java/dooya/see/user/presentation/UserIntegrationTest.java
+++ b/src/test/java/dooya/see/user/presentation/UserIntegrationTest.java
@@ -201,7 +201,7 @@ class UserIntegrationTest {
         UserUpdateRequest request = nickNameUpdateRequest();
 
         // Act && Assert
-        mockMvc.perform(put("/api/users")
+        mockMvc.perform(put("/api/users/nick-name")
                         .cookie(new Cookie("Authorization", testToken))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
@@ -217,7 +217,7 @@ class UserIntegrationTest {
         String testToken = jwtUtil.createAccessToken(testUser.getId(), "test@fail.com", testUser.getRole());
 
         // Act & Assert
-        mockMvc.perform(put("/api/users")
+        mockMvc.perform(put("/api/users/nick-name")
                         .cookie(new Cookie("Authorization", testToken))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))

--- a/src/test/java/dooya/see/user/presentation/UserIntegrationTest.java
+++ b/src/test/java/dooya/see/user/presentation/UserIntegrationTest.java
@@ -7,7 +7,7 @@ import dooya.see.user.domain.User;
 import dooya.see.user.infrastructure.UserJpaRepository;
 import dooya.see.user.presentation.dto.PasswordUpdateRequest;
 import dooya.see.user.presentation.dto.UserSignUpRequest;
-import dooya.see.user.presentation.dto.UserUpdateRequest;
+import dooya.see.user.presentation.dto.NickNameUpdateRequest;
 import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -198,7 +198,7 @@ class UserIntegrationTest {
     @Test
     void userNickName_update_success() throws Exception {
         // Arrange
-        UserUpdateRequest request = nickNameUpdateRequest();
+        NickNameUpdateRequest request = nickNameUpdateRequest();
 
         // Act && Assert
         mockMvc.perform(put("/api/users/nick-name")
@@ -213,7 +213,7 @@ class UserIntegrationTest {
     @Test
     void userNickName_update_fail() throws Exception {
         // Arrange
-        UserUpdateRequest request = nickNameUpdateRequest();
+        NickNameUpdateRequest request = nickNameUpdateRequest();
         String testToken = jwtUtil.createAccessToken(testUser.getId(), "test@fail.com", testUser.getRole());
 
         // Act & Assert

--- a/src/test/java/dooya/see/user/presentation/UserPresentationMapperTest.java
+++ b/src/test/java/dooya/see/user/presentation/UserPresentationMapperTest.java
@@ -53,10 +53,10 @@ public class UserPresentationMapperTest {
     @Test
     void convert_UserUpdateRequest_to_UserUpdateCommand() {
         // Arrange
-        UserUpdateRequest request = nickNameUpdateRequest();
+        NickNameUpdateRequest request = nickNameUpdateRequest();
 
         // Act
-        UserUpdateCommand command = toUpdateCommand(request);
+        NickNameUpdateCommand command = toUpdateCommand(request);
 
         // Assert
         assertThat(request.nickName()).isEqualTo(command.nickName());
@@ -69,7 +69,7 @@ public class UserPresentationMapperTest {
         UserResult result = testUserResult();
 
         // Act
-        UserUpdateResponse response = toUpdateResponse(result);
+        NickNameUpdateResponse response = toUpdateResponse(result);
 
         // Assert
         assertThat(response.nickName()).isEqualTo(result.nickName());


### PR DESCRIPTION
## 📌 Issue

<!-- 해결하려는 이슈 번호나 주제를 명확하게 적어주세요. -->

- closed #68

---

## 🧐 현재 상황

<!-- 현재 발생한 문제, 개선이 필요한 사항을 간략히 설명해주세요. -->

- 엔드포인트 경로 추가 및 DTO 네이밍 명확하게 변경

---

## 🎯 목표

<!-- 이슈를 통해 달성하고자 하는 목표를 설명해주세요. -->

- 엔드포인트 경로 추가 및 DTO 네이밍 명확하게 변경

---

## 🛠 작업 내용

- 작업 할 내용을 입력해주세요.

- [x] 엔드포인트 추가
- [x] 테스트 검증
- [x] DTO 수정

---

## 🚀 기타 사항

<!-- 리뷰어가 추가적으로 알아야 할 사항이 있다면 기재해주세요. -->

- 추가적인 내용을 작성해주세요.(참고 자료, 협업 내용)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - 닉네임 변경 관련 요청 및 응답, 서비스, 컨트롤러, 매퍼 등에서 기존의 일반적인 UserUpdate 타입을 NickNameUpdate 타입으로 명확하게 분리하였습니다.
  - 닉네임 변경 API의 엔드포인트가 "/api/users"에서 "/api/users/nick-name"으로 변경되었습니다.

- **Tests**
  - 닉네임 변경 테스트 코드 전반이 새로운 NickNameUpdate 타입 및 엔드포인트를 반영하도록 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->