### PR TITLE
유저 정보 통합 수정 기능 추가

### DIFF
--- a/src/main/java/dooya/see/user/application/service/UserUpdateService.java
+++ b/src/main/java/dooya/see/user/application/service/UserUpdateService.java
@@ -37,4 +37,6 @@ public interface UserUpdateService {
     PasswordUpdateResult updatePassword(String email, PasswordUpdateCommand command);
 
     UserResult updateProfileImage(String email, MultipartFile profileImage);
+
+    UserResult updateProfile(String email, NickNameUpdateCommand command, MultipartFile profileImage);
 }

--- a/src/main/java/dooya/see/user/application/service/impl/UserUpdateServiceImpl.java
+++ b/src/main/java/dooya/see/user/application/service/impl/UserUpdateServiceImpl.java
@@ -59,4 +59,21 @@ public class UserUpdateServiceImpl implements UserUpdateService {
 
         return toResult(user);
     }
+
+    @Transactional
+    @Override
+    public UserResult updateProfile(String email, NickNameUpdateCommand command, MultipartFile profileImage) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        if (command != null && command.nickName() != null) {
+            user.updateNickName(command.nickName());
+        }
+
+        if (profileImage != null && !profileImage.isEmpty()) {
+            String uploadImageUrl = s3Uploader.upload(profileImage, "profile");
+            user.updateProfileImage(uploadImageUrl);
+        }
+        return toResult(user);
+    }
 }

--- a/src/main/java/dooya/see/user/presentation/UserController.java
+++ b/src/main/java/dooya/see/user/presentation/UserController.java
@@ -8,6 +8,7 @@ import dooya.see.user.application.service.UserUpdateService;
 import dooya.see.user.application.service.UserValidator;
 import dooya.see.user.presentation.dto.*;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -156,6 +157,26 @@ public class UserController {
                                                            @RequestPart MultipartFile profileImage) {
         String email = loginUser.getUsername();
         UserResult result = userUpdateService.updateProfileImage(email, profileImage);
+
+        return ResponseEntity.ok().body(toResponse(result));
+    }
+
+    @Operation(
+            summary = "프로필 통합 수정",
+            description = "닉네임과 프로필 이미지를 동시에 수정합니다. 닉네임은 JSON 형식으로, 프로필 이미지는 이미지 파일로 전송합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "프로필 수정 성공",
+                    content = @Content(schema = @Schema(implementation = UserResponse.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청", content = @Content)
+    })
+    @PutMapping(value = "/profile", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<UserResponse> updateProfile(@AuthenticationPrincipal LoginUser loginUser,
+                                                      @RequestPart NickNameUpdateRequest request,
+                                                      @RequestPart MultipartFile profileImage) {
+        String email = loginUser.getUsername();
+        NickNameUpdateCommand command = UserPresentationMapper.toUpdateCommand(request);
+        UserResult result = userUpdateService.updateProfile(email, command, profileImage);
 
         return ResponseEntity.ok().body(toResponse(result));
     }

--- a/src/main/java/dooya/see/user/presentation/UserController.java
+++ b/src/main/java/dooya/see/user/presentation/UserController.java
@@ -168,12 +168,12 @@ public class UserController {
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "프로필 수정 성공",
                     content = @Content(schema = @Schema(implementation = UserResponse.class))),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청", content = @Content)
+            @ApiResponse(responseCode = "404", description = "사용자 정보를 찾을 수 없음", content = @Content)
     })
     @PutMapping(value = "/profile", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<UserResponse> updateProfile(@AuthenticationPrincipal LoginUser loginUser,
-                                                      @RequestPart NickNameUpdateRequest request,
-                                                      @RequestPart MultipartFile profileImage) {
+                                                      @RequestPart(required = false) NickNameUpdateRequest request,
+                                                      @RequestPart(required = false) MultipartFile profileImage) {
         String email = loginUser.getUsername();
         NickNameUpdateCommand command = UserPresentationMapper.toUpdateCommand(request);
         UserResult result = userUpdateService.updateProfile(email, command, profileImage);

--- a/src/test/java/dooya/see/user/application/UserUpdateServiceTest.java
+++ b/src/test/java/dooya/see/user/application/UserUpdateServiceTest.java
@@ -112,7 +112,7 @@ public class UserUpdateServiceTest {
 
     @DisplayName("유저 프로필 이미지 업데이트 성공 테스트")
     @Test
-    void user_profileUpdate_success() {
+    void user_profileImageUpdate_success() {
         // Arrange
         String email = "test@example.com";
         String expectedImageUrl = "https://s3.amazon.com/profile/image.png";
@@ -136,7 +136,7 @@ public class UserUpdateServiceTest {
 
     @DisplayName("유저 프로필 이미지 업데이트 실패 테스트 - 유저가 존재하지 않음")
     @Test
-    void user_profileUpdate_fail() {
+    void user_profileImageUpdate_fail() {
         // Arrange
         MultipartFile mockFile = mock(MultipartFile.class);
         doThrow(new CustomException(ErrorCode.USER_NOT_FOUND)).when(userRepository).findByEmail(testUser.getEmail());
@@ -147,5 +147,45 @@ public class UserUpdateServiceTest {
                 .hasMessageContaining("존재하지 않는 사용자입니다.");
 
         then(userRepository).should(times(1)).findByEmail(testUser.getEmail());
+    }
+
+    @DisplayName("유저 프로필 업데이트 실패 테스트 - 유저가 존재하지 않음")
+    @Test
+    void user_profileUpdate_fail() {
+        // Arrange
+        MultipartFile mockFile = mock(MultipartFile.class);
+        NickNameUpdateCommand command = updateCommand();
+        doThrow(new CustomException(ErrorCode.USER_NOT_FOUND)).when(userRepository).findByEmail(testUser.getEmail());
+        // Act && Assert
+        assertThatCode(() -> userUpdateService.updateProfile(testUser.getEmail(), command, mockFile))
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining("존재하지 않는 사용자입니다.");
+
+        then(userRepository).should(times(1)).findByEmail(testUser.getEmail());
+    }
+
+    @DisplayName("유저 프로필 업데이트 성공 테스트")
+    @Test
+    void user_profileUpdate_success() {
+        // Arrange
+        String email = "test@example.com";
+        String expectedImageUrl = "https://s3.amazon.com/profile/image.png";
+        NickNameUpdateCommand command = updateCommand();
+
+        MultipartFile mockFile = mock(MultipartFile.class);
+        User testUser = testUser();
+
+        given(s3Uploader.upload(mockFile, "profile")).willReturn(expectedImageUrl);
+        given(userRepository.findByEmail(email)).willReturn(Optional.of(testUser));
+
+        // Act
+        UserResult result = userUpdateService.updateProfile(email, command, mockFile);
+
+        // Assert
+        assertThat(result.profileImageUrl()).isEqualTo(expectedImageUrl);
+        assertThat(testUser.getProfileImageUrl()).isEqualTo(expectedImageUrl);
+
+        then(s3Uploader).should(times(1)).upload(mockFile, "profile");
+        then(userRepository).should(times(1)).findByEmail(email);
     }
 }

--- a/src/test/java/dooya/see/user/presentation/UserControllerTest.java
+++ b/src/test/java/dooya/see/user/presentation/UserControllerTest.java
@@ -236,6 +236,8 @@ public class UserControllerTest {
                 "fake-image-content".getBytes()
         );
 
+        given(userUpdateService.updateProfile(anyString(), any(), any())).willReturn(UserFixture.testUserResult());
+
         // when
         mockMvc.perform(multipart("/api/users/profile")
                         .file(nickNamePart)

--- a/src/test/java/dooya/see/user/presentation/UserControllerTest.java
+++ b/src/test/java/dooya/see/user/presentation/UserControllerTest.java
@@ -31,6 +31,9 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.nio.charset.StandardCharsets;
+
+import static dooya.see.common.UserFixture.nickNameUpdateRequest;
 import static dooya.see.common.UserFixture.signUpRequest;
 
 import static org.mockito.BDDMockito.*;
@@ -208,5 +211,44 @@ public class UserControllerTest {
 
         // then
         then(userUpdateService).should().updateProfileImage(email, mockImage);
+    }
+
+    @DisplayName("/profile 경로로 PUT 요청 시 userUpdateService.updateProfile(email, command, profileImage) 호출 여부 검증")
+    @Test
+    void put_WhenCalled_InvokeUpdateProfile() throws Exception {
+        // given
+        String email = "test@see.com";
+        LoginUser loginUser = new LoginUser(1L, "test@see.com", "USER");
+        NickNameUpdateCommand command = UserFixture.updateCommand();
+        String nickNameJson = objectMapper.writeValueAsString(nickNameUpdateRequest());
+
+        MockMultipartFile nickNamePart = new MockMultipartFile(
+                "request",
+                null,
+                MediaType.APPLICATION_JSON_VALUE,
+                nickNameJson.getBytes(StandardCharsets.UTF_8)
+        );
+
+        MockMultipartFile mockImage = new MockMultipartFile(
+                "profileImage",
+                "profile.jpg",
+                "image/jpeg",
+                "fake-image-content".getBytes()
+        );
+
+        // when
+        mockMvc.perform(multipart("/api/users/profile")
+                        .file(nickNamePart)
+                        .file(mockImage)
+                        .cookie(new Cookie("Authorization", testToken))
+                        .with(user(loginUser))
+                        .with(request -> {
+                            request.setMethod("PUT");
+                            return request;
+                        }))
+                .andExpect(status().isOk());
+
+        // then
+        then(userUpdateService).should().updateProfile(email, command, mockImage);
     }
 }

--- a/src/test/java/dooya/see/user/presentation/UserIntegrationTest.java
+++ b/src/test/java/dooya/see/user/presentation/UserIntegrationTest.java
@@ -25,6 +25,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.nio.charset.StandardCharsets;
 import java.util.stream.Stream;
 
 import static dooya.see.common.UserFixture.*;
@@ -260,7 +261,7 @@ class UserIntegrationTest {
 
     @DisplayName("유저 프로필 이미지 업데이트 성공 테스트")
     @Test
-    void userProfile_Update_Success() throws Exception {
+    void userProfileImage_Update_Success() throws Exception {
         // Arrange
         MockMultipartFile mockImage = new MockMultipartFile(
                 "profileImage",
@@ -279,6 +280,40 @@ class UserIntegrationTest {
                         })
                 )
                 .andExpect(status().isOk())
+                .andExpect(jsonPath("$.profileImageUrl").isNotEmpty());
+    }
+
+    @DisplayName("유저 프로필 업데이트 성공 테스트")
+    @Test
+    void userProfile_Update_Success() throws Exception {
+        // Arrange
+        String nickNameJson = objectMapper.writeValueAsString(nickNameUpdateRequest());
+
+        MockMultipartFile nickNamePart = new MockMultipartFile(
+                "request",
+                null,
+                MediaType.APPLICATION_JSON_VALUE,
+                nickNameJson.getBytes(StandardCharsets.UTF_8)
+        );
+
+        MockMultipartFile mockImage = new MockMultipartFile(
+                "profileImage",
+                "profile.jpg",
+                "image/jpeg",
+                "fake-image-content".getBytes()
+        );
+
+        // Act && Assert
+        mockMvc.perform(multipart("/api/users/profile")
+                        .file(nickNamePart)
+                        .file(mockImage)
+                        .cookie(new Cookie("Authorization", testToken))
+                        .with(request -> {
+                            request.setMethod("PUT");
+                            return request;
+                        }))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.nickName").value(nickNameUpdateRequest().nickName()))
                 .andExpect(jsonPath("$.profileImageUrl").isNotEmpty());
     }
 }


### PR DESCRIPTION
## 📌 Issue

<!-- 해결하려는 이슈 번호나 주제를 명확하게 적어주세요. -->

- closed #70

---

## 🧐 현재 상황

<!-- 현재 발생한 문제, 개선이 필요한 사항을 간략히 설명해주세요. -->

- 유저 정보 통합으로 수정하는 API가 존재하지 않음

---

## 🎯 목표

<!-- 이슈를 통해 달성하고자 하는 목표를 설명해주세요. -->

- 유저 정보를 한번에 수정할수 있도록 함

---

## 🛠 작업 내용

- 작업 할 내용을 입력해주세요.

- [x] 테스트 작성
- [x] Controller 메서드 구현

---

## 🚀 기타 사항

<!-- 리뷰어가 추가적으로 알아야 할 사항이 있다면 기재해주세요. -->

- 추가적인 내용을 작성해주세요.(참고 자료, 협업 내용)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 닉네임과 프로필 이미지를 한 번에 수정할 수 있는 API 엔드포인트가 추가되었습니다.

- **Bug Fixes**
  - 기존 프로필 이미지 업데이트 테스트 명칭이 더 명확하게 변경되었습니다.

- **Tests**
  - 닉네임과 프로필 이미지를 동시에 수정하는 기능에 대한 단위 테스트 및 통합 테스트가 추가되었습니다.
  - 기존 테스트가 새로운 엔드포인트 및 기능에 맞게 보완되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->