### PR TITLE
Member Primary Adapter 구현 (register 기능)

### DIFF
--- a/src/main/java/dooya/see/adapter/ApiControllerAdvice.java
+++ b/src/main/java/dooya/see/adapter/ApiControllerAdvice.java
@@ -18,7 +18,7 @@ public class ApiControllerAdvice extends ResponseEntityExceptionHandler {
     }
 
     @ExceptionHandler({DuplicateEmailException.class, DuplicateProfileException.class})
-    public ProblemDetail emailExceptionHandler(DuplicateEmailException exception) {
+    public ProblemDetail conflictExceptionHandler(Exception exception) {
         return getProblemDetail(HttpStatus.CONFLICT, exception);
     }
 

--- a/src/main/java/dooya/see/adapter/ApiControllerAdvice.java
+++ b/src/main/java/dooya/see/adapter/ApiControllerAdvice.java
@@ -1,0 +1,33 @@
+package dooya.see.adapter;
+
+import dooya.see.domain.member.DuplicateEmailException;
+import dooya.see.domain.member.DuplicateProfileException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import java.time.LocalDateTime;
+
+@ControllerAdvice
+public class ApiControllerAdvice extends ResponseEntityExceptionHandler {
+    @ExceptionHandler(Exception.class)
+    public ProblemDetail handlerException(Exception exception) {
+        return getProblemDetail(HttpStatus.INTERNAL_SERVER_ERROR, exception);
+    }
+
+    @ExceptionHandler({DuplicateEmailException.class, DuplicateProfileException.class})
+    public ProblemDetail emailExceptionHandler(DuplicateEmailException exception) {
+        return getProblemDetail(HttpStatus.CONFLICT, exception);
+    }
+
+    private static ProblemDetail getProblemDetail(HttpStatus status, Exception exception) {
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(status, exception.getMessage());
+
+        problemDetail.setProperty("timestamp", LocalDateTime.now());
+        problemDetail.setProperty("exception", exception.getClass().getSimpleName());
+
+        return problemDetail;
+    }
+}

--- a/src/main/java/dooya/see/adapter/webapi/MemberApi.java
+++ b/src/main/java/dooya/see/adapter/webapi/MemberApi.java
@@ -1,0 +1,24 @@
+package dooya.see.adapter.webapi;
+
+import dooya.see.adapter.webapi.dto.MemberRegisterResponse;
+import dooya.see.application.member.provided.MemberRegister;
+import dooya.see.domain.member.Member;
+import dooya.see.domain.member.MemberRegisterRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class MemberApi {
+    private final MemberRegister memberRegister;
+
+    @PostMapping("/api/members")
+    public MemberRegisterResponse register(@RequestBody @Valid MemberRegisterRequest request) {
+        Member member = memberRegister.register(request);
+
+        return MemberRegisterResponse.of(member);
+    }
+}

--- a/src/main/java/dooya/see/adapter/webapi/dto/MemberRegisterResponse.java
+++ b/src/main/java/dooya/see/adapter/webapi/dto/MemberRegisterResponse.java
@@ -1,0 +1,10 @@
+package dooya.see.adapter.webapi.dto;
+
+import dooya.see.domain.member.Member;
+
+public record MemberRegisterResponse(Long memberId, String email) {
+    public static MemberRegisterResponse of(Member member
+    ) {
+        return new MemberRegisterResponse(member.getId(), member.getEmail().address());
+    }
+}

--- a/src/test/java/dooya/see/adapter/security/SecurePasswordEncoderTest.java
+++ b/src/test/java/dooya/see/adapter/security/SecurePasswordEncoderTest.java
@@ -1,0 +1,19 @@
+package dooya.see.adapter.security;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SecurePasswordEncoderTest {
+    @Test
+    @DisplayName("비밀번호 암호화 후 올바른 비밀번호는 검증 성공하고 잘못된 비밀번호는 검증 실패한다")
+    void securePasswordEncoder() {
+        SecurePasswordEncoder securePasswordEncoder = new SecurePasswordEncoder();
+
+        String passwordHash = securePasswordEncoder.encode("secret");
+
+        assertThat(securePasswordEncoder.matches("secret", passwordHash)).isTrue();
+        assertThat(securePasswordEncoder.matches("wrong", passwordHash)).isFalse();
+    }
+}

--- a/src/test/java/dooya/see/adapter/webapi/MemberApiTest.java
+++ b/src/test/java/dooya/see/adapter/webapi/MemberApiTest.java
@@ -1,13 +1,39 @@
 package dooya.see.adapter.webapi;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dooya.see.domain.member.MemberFixture;
+import dooya.see.domain.member.MemberRegisterRequest;
 import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.assertj.MockMvcTester;
+import org.springframework.test.web.servlet.assertj.MvcTestResult;
 import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
 @AutoConfigureMockMvc
 @Transactional
 @RequiredArgsConstructor
 class MemberApiTest {
+    final ObjectMapper objectMapper;
+    final MockMvcTester mvcTester;
+
+    @Test
+    @DisplayName("")
+    void register() throws JsonProcessingException {
+        MemberRegisterRequest request = MemberFixture.createMemberRegisterRequest();
+        String requestJson = objectMapper.writeValueAsString(request);
+
+        MvcTestResult result = mvcTester.post().uri("/api/members").contentType(MediaType.APPLICATION_JSON)
+                .content(requestJson).exchange();
+
+        assertThat(result)
+                .hasStatusOk();
+    }
 }

--- a/src/test/java/dooya/see/adapter/webapi/MemberApiTest.java
+++ b/src/test/java/dooya/see/adapter/webapi/MemberApiTest.java
@@ -2,11 +2,16 @@ package dooya.see.adapter.webapi;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import dooya.see.adapter.webapi.dto.MemberRegisterResponse;
+import dooya.see.application.member.required.MemberRepository;
+import dooya.see.domain.member.Member;
 import dooya.see.domain.member.MemberFixture;
 import dooya.see.domain.member.MemberRegisterRequest;
+import dooya.see.domain.member.MemberStatus;
 import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
@@ -14,6 +19,9 @@ import org.springframework.test.web.servlet.assertj.MockMvcTester;
 import org.springframework.test.web.servlet.assertj.MvcTestResult;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.io.UnsupportedEncodingException;
+
+import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
@@ -23,10 +31,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 class MemberApiTest {
     final ObjectMapper objectMapper;
     final MockMvcTester mvcTester;
+    final MemberRepository memberRepository;
 
     @Test
     @DisplayName("")
-    void register() throws JsonProcessingException {
+    void register() throws JsonProcessingException, UnsupportedEncodingException {
         MemberRegisterRequest request = MemberFixture.createMemberRegisterRequest();
         String requestJson = objectMapper.writeValueAsString(request);
 
@@ -34,6 +43,18 @@ class MemberApiTest {
                 .content(requestJson).exchange();
 
         assertThat(result)
-                .hasStatusOk();
+                .hasStatusOk()
+                .bodyJson()
+                .hasPathSatisfying("$.memberId", value -> assertThat(value).isNotNull())
+                .hasPathSatisfying("$.email", value -> assertThat(value).isEqualTo(request.email()));
+
+        MemberRegisterResponse response =
+                objectMapper.readValue(result.getResponse().getContentAsString(), MemberRegisterResponse.class);
+
+        Member member = memberRepository.findById(response.memberId()).orElseThrow();
+
+        assertThat(member.getEmail().address()).isEqualTo(request.email());
+        assertThat(member.getNickname()).isEqualTo(request.nickname());
+        assertThat(member.getStatus()).isEqualTo(MemberStatus.ACTIVE);
     }
 }

--- a/src/test/java/dooya/see/adapter/webapi/MemberApiTest.java
+++ b/src/test/java/dooya/see/adapter/webapi/MemberApiTest.java
@@ -22,7 +22,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.io.UnsupportedEncodingException;
 
 import static dooya.see.domain.member.MemberFixture.*;
-import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 
@@ -37,7 +36,7 @@ class MemberApiTest {
     final MemberRegister memberRegister;
 
     @Test
-    @DisplayName("")
+    @DisplayName("회원 등록 요청 시 회원 ID와 이메일이 포함된 응답을 반환하고 데이터베이스에 저장된다")
     void register() throws JsonProcessingException, UnsupportedEncodingException {
         MemberRegisterRequest request = createMemberRegisterRequest();
         String requestJson = objectMapper.writeValueAsString(request);
@@ -62,7 +61,7 @@ class MemberApiTest {
     }
 
     @Test
-    @DisplayName("")
+    @DisplayName("동일한 이메일로 회원 등록 시도 시 409 Conflict 상태 코드를 반환한다")
     void duplicateEmail() throws JsonProcessingException {
         memberRegister.register(createMemberRegisterRequest());
 

--- a/src/test/java/dooya/see/adapter/webapi/MemberApiTest.java
+++ b/src/test/java/dooya/see/adapter/webapi/MemberApiTest.java
@@ -3,17 +3,17 @@ package dooya.see.adapter.webapi;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dooya.see.adapter.webapi.dto.MemberRegisterResponse;
+import dooya.see.application.member.provided.MemberRegister;
 import dooya.see.application.member.required.MemberRepository;
 import dooya.see.domain.member.Member;
-import dooya.see.domain.member.MemberFixture;
 import dooya.see.domain.member.MemberRegisterRequest;
 import dooya.see.domain.member.MemberStatus;
 import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.assertj.MockMvcTester;
 import org.springframework.test.web.servlet.assertj.MvcTestResult;
@@ -21,8 +21,10 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.io.UnsupportedEncodingException;
 
+import static dooya.see.domain.member.MemberFixture.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -32,11 +34,12 @@ class MemberApiTest {
     final ObjectMapper objectMapper;
     final MockMvcTester mvcTester;
     final MemberRepository memberRepository;
+    final MemberRegister memberRegister;
 
     @Test
     @DisplayName("")
     void register() throws JsonProcessingException, UnsupportedEncodingException {
-        MemberRegisterRequest request = MemberFixture.createMemberRegisterRequest();
+        MemberRegisterRequest request = createMemberRegisterRequest();
         String requestJson = objectMapper.writeValueAsString(request);
 
         MvcTestResult result = mvcTester.post().uri("/api/members").contentType(MediaType.APPLICATION_JSON)
@@ -56,5 +59,21 @@ class MemberApiTest {
         assertThat(member.getEmail().address()).isEqualTo(request.email());
         assertThat(member.getNickname()).isEqualTo(request.nickname());
         assertThat(member.getStatus()).isEqualTo(MemberStatus.ACTIVE);
+    }
+
+    @Test
+    @DisplayName("")
+    void duplicateEmail() throws JsonProcessingException {
+        memberRegister.register(createMemberRegisterRequest());
+
+        MemberRegisterRequest request = createMemberRegisterRequest();
+        String requestJson = objectMapper.writeValueAsString(request);
+
+        MvcTestResult result = mvcTester.post().uri("/api/members").contentType(MediaType.APPLICATION_JSON)
+                .content(requestJson).exchange();
+
+        assertThat(result)
+                .apply(print())
+                .hasStatus(HttpStatus.CONFLICT);
     }
 }

--- a/src/test/java/dooya/see/adapter/webapi/MemberApiTest.java
+++ b/src/test/java/dooya/see/adapter/webapi/MemberApiTest.java
@@ -1,0 +1,13 @@
+package dooya.see.adapter.webapi;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@RequiredArgsConstructor
+class MemberApiTest {
+}


### PR DESCRIPTION
## 📌 Issue

<!-- 해결하려는 이슈 번호나 주제를 명확하게 적어주세요. -->

- closed #100 

---

## 🧐 현재 상황

<!-- 현재 발생한 문제, 개선이 필요한 사항을 간략히 설명해주세요. -->

- Member Primary Adapter 구현 (register 기능), 다음 기능은 사용자 관련 기능이라 로그인 작업 후 진행 예정

---

## 🎯 목표

<!-- 이슈를 통해 달성하고자 하는 목표를 설명해주세요. -->

- Member Primary Adapter 구현 (register 기능)

---

## 🛠 작업 내용

- 작업 할 내용을 입력해주세요.

- [x] Member Primary Adapter 구현(register 기능)
- [x] ApiControllerAdvice 구현
- [x] 테스트 작성

---

## 🚀 기타 사항

<!-- 리뷰어가 추가적으로 알아야 할 사항이 있다면 기재해주세요. -->

- 추가적인 내용을 작성해주세요.(참고 자료, 협업 내용)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 회원 가입 API를 추가하여 요청 시 회원 ID와 이메일을 반환합니다.
  - 전역 예외 처리로 표준화된 오류 응답을 제공합니다. 일반 예외는 500, 중복 이메일/프로필 등은 409 상태 코드로 응답합니다.
- **Tests**
  - 비밀번호 인코더 동작을 검증하는 단위 테스트를 추가했습니다.
  - 회원 가입 API 통합 테스트를 추가하여 정상 등록 및 중복 이메일 시 409 응답을 검증합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->