### PR TITLE
Member 도메인 로그인 기능 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,6 +31,9 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework.security:spring-security-core")
+    implementation("io.jsonwebtoken:jjwt-api:0.12.6")
+    implementation("io.jsonwebtoken:jjwt-impl:0.12.6")
+    implementation("io.jsonwebtoken:jjwt-jackson:0.12.6")
 
     compileOnly("org.projectlombok:lombok")
     developmentOnly("org.springframework.boot:spring-boot-docker-compose")

--- a/src/main/java/dooya/see/adapter/ApiControllerAdvice.java
+++ b/src/main/java/dooya/see/adapter/ApiControllerAdvice.java
@@ -1,7 +1,9 @@
 package dooya.see.adapter;
 
+import dooya.see.domain.member.AuthenticateException;
 import dooya.see.domain.member.DuplicateEmailException;
 import dooya.see.domain.member.DuplicateProfileException;
+import dooya.see.domain.member.MemberNotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
 import org.springframework.web.bind.annotation.ControllerAdvice;
@@ -20,6 +22,16 @@ public class ApiControllerAdvice extends ResponseEntityExceptionHandler {
     @ExceptionHandler({DuplicateEmailException.class, DuplicateProfileException.class})
     public ProblemDetail conflictExceptionHandler(Exception exception) {
         return getProblemDetail(HttpStatus.CONFLICT, exception);
+    }
+
+    @ExceptionHandler(AuthenticateException.class)
+    public ProblemDetail unauthorizedExceptionHandler(Exception exception) {
+        return getProblemDetail(HttpStatus.UNAUTHORIZED, exception);
+    }
+
+    @ExceptionHandler(MemberNotFoundException.class)
+    public ProblemDetail notFoundExceptionHandler(Exception exception) {
+        return getProblemDetail(HttpStatus.NOT_FOUND, exception);
     }
 
     private static ProblemDetail getProblemDetail(HttpStatus status, Exception exception) {

--- a/src/main/java/dooya/see/adapter/security/JwtTokenManager.java
+++ b/src/main/java/dooya/see/adapter/security/JwtTokenManager.java
@@ -1,0 +1,70 @@
+package dooya.see.adapter.security;
+
+import dooya.see.application.member.required.TokenManager;
+import dooya.see.domain.member.AuthenticateException;
+import dooya.see.domain.member.Member;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.util.Date;
+
+@Component
+public class JwtTokenManager implements TokenManager {
+    private final SecretKey key;
+    private final long expiration = 24 * 60 * 60 * 1000;
+
+    public JwtTokenManager(@Value("${jwt.secret:myDefaultSecretKeyThatIsLongEnoughForHS256}") String secret) {
+        // HMAC-SHA256은 최소 32바이트(256비트) 키 필요
+        if (secret.length() < 32) {
+            secret = secret + "0".repeat(32 - secret.length());
+        }
+        this.key = Keys.hmacShaKeyFor(secret.getBytes());
+    }
+
+    @Override
+    public String generateToken(Member member) {
+        return Jwts.builder()
+                .subject(member.getEmail().address())
+                .claim("memberId", member.getId())
+                .claim("nickname", member.getNickname())
+                .claim("status", member.getStatus().name())
+                .issuedAt(new Date())
+                .expiration(new Date(System.currentTimeMillis() + expiration))
+                .signWith(key)
+                .compact();
+    }
+
+    @Override
+    public Claims parseToken(String token) {
+        try {
+            return Jwts.parser()
+                    .verifyWith(key)
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload();
+        } catch (JwtException e) {
+            throw new AuthenticateException("유효하지 않은 토큰입니다: " + e.getMessage());
+        }
+    }
+
+    @Override
+    public boolean isTokenValid(String token) {
+        try {
+            parseToken(token);
+            return true;
+        } catch (AuthenticateException e) {
+            return false;
+        }
+    }
+
+    @Override
+    public String extractEmailFromToken(String token) {
+        Claims claims = parseToken(token);
+        return claims.getSubject();
+    }
+}

--- a/src/main/java/dooya/see/adapter/security/JwtTokenManager.java
+++ b/src/main/java/dooya/see/adapter/security/JwtTokenManager.java
@@ -53,16 +53,6 @@ public class JwtTokenManager implements TokenManager {
     }
 
     @Override
-    public boolean isTokenValid(String token) {
-        try {
-            parseToken(token);
-            return true;
-        } catch (AuthenticateException e) {
-            return false;
-        }
-    }
-
-    @Override
     public String extractEmailFromToken(String token) {
         Claims claims = parseToken(token);
         return claims.getSubject();

--- a/src/main/java/dooya/see/adapter/security/JwtTokenManager.java
+++ b/src/main/java/dooya/see/adapter/security/JwtTokenManager.java
@@ -39,8 +39,7 @@ public class JwtTokenManager implements TokenManager {
                 .compact();
     }
 
-    @Override
-    public Claims parseToken(String token) {
+    private Claims parseToken(String token) {
         try {
             return Jwts.parser()
                     .verifyWith(key)
@@ -48,7 +47,7 @@ public class JwtTokenManager implements TokenManager {
                     .parseSignedClaims(token)
                     .getPayload();
         } catch (JwtException e) {
-            throw new AuthenticateException("유효하지 않은 토큰입니다: " + e.getMessage());
+            throw new AuthenticateException("유효하지 않은 토큰입니다");
         }
     }
 

--- a/src/main/java/dooya/see/adapter/webapi/MemberApi.java
+++ b/src/main/java/dooya/see/adapter/webapi/MemberApi.java
@@ -1,8 +1,12 @@
 package dooya.see.adapter.webapi;
 
+import dooya.see.adapter.webapi.dto.MemberAuthResponse;
 import dooya.see.adapter.webapi.dto.MemberRegisterResponse;
+import dooya.see.application.member.provided.MemberAuth;
 import dooya.see.application.member.provided.MemberRegister;
+import dooya.see.domain.member.LoginResult;
 import dooya.see.domain.member.Member;
+import dooya.see.domain.member.MemberAuthRequest;
 import dooya.see.domain.member.MemberRegisterRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -14,11 +18,19 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class MemberApi {
     private final MemberRegister memberRegister;
+    private final MemberAuth memberAuth;
 
     @PostMapping("/api/members")
     public MemberRegisterResponse register(@RequestBody @Valid MemberRegisterRequest request) {
         Member member = memberRegister.register(request);
 
         return MemberRegisterResponse.of(member);
+    }
+
+    @PostMapping("/api/members/login")
+    public MemberAuthResponse login(@RequestBody @Valid MemberAuthRequest request) {
+        LoginResult result = memberAuth.login(request);
+
+        return MemberAuthResponse.from(result);
     }
 }

--- a/src/main/java/dooya/see/adapter/webapi/MemberApi.java
+++ b/src/main/java/dooya/see/adapter/webapi/MemberApi.java
@@ -1,18 +1,15 @@
 package dooya.see.adapter.webapi;
 
 import dooya.see.adapter.webapi.dto.MemberAuthResponse;
+import dooya.see.adapter.webapi.dto.MemberProfileResponse;
 import dooya.see.adapter.webapi.dto.MemberRegisterResponse;
 import dooya.see.application.member.provided.MemberAuth;
 import dooya.see.application.member.provided.MemberRegister;
-import dooya.see.domain.member.LoginResult;
-import dooya.see.domain.member.Member;
-import dooya.see.domain.member.MemberAuthRequest;
-import dooya.see.domain.member.MemberRegisterRequest;
+import dooya.see.domain.member.*;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.http.HttpHeaders;
 
 @RestController
 @RequiredArgsConstructor
@@ -32,5 +29,20 @@ public class MemberApi {
         LoginResult result = memberAuth.login(request);
 
         return MemberAuthResponse.from(result);
+    }
+
+    @GetMapping("/api/members/my")
+    public MemberProfileResponse getCurrentMember(@RequestHeader(value = HttpHeaders.AUTHORIZATION, required = false) String authorizationHeader) {
+        String token = extractTokenFromHeader(authorizationHeader);
+        Member member = memberAuth.getCurrentMember(token);
+
+        return MemberProfileResponse.from(member);
+    }
+
+    private String extractTokenFromHeader(String authorizationHeader) {
+        if (authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {
+            throw new AuthenticateException("Authorization 헤더가 올바르지 않습니다");
+        }
+        return authorizationHeader.substring(7);
     }
 }

--- a/src/main/java/dooya/see/adapter/webapi/dto/MemberAuthResponse.java
+++ b/src/main/java/dooya/see/adapter/webapi/dto/MemberAuthResponse.java
@@ -1,0 +1,22 @@
+package dooya.see.adapter.webapi.dto;
+
+import dooya.see.domain.member.LoginResult;
+import dooya.see.domain.member.Member;
+
+public record MemberAuthResponse(
+        Long memberId,
+        String email,
+        String nickname,
+        String accessToken
+) {
+    public static MemberAuthResponse from(LoginResult loginResult) {
+        Member member = loginResult.member();
+
+        return new MemberAuthResponse(
+                member.getId(),
+                member.getEmail().address(),
+                member.getNickname(),
+                loginResult.accessToken()
+        );
+    }
+}

--- a/src/main/java/dooya/see/adapter/webapi/dto/MemberProfileResponse.java
+++ b/src/main/java/dooya/see/adapter/webapi/dto/MemberProfileResponse.java
@@ -1,0 +1,20 @@
+package dooya.see.adapter.webapi.dto;
+
+import dooya.see.domain.member.Member;
+
+public record MemberProfileResponse(
+        Long memberId,
+        String email,
+        String nickname,
+        String profile
+) {
+    public static MemberProfileResponse from(Member member) {
+        return new MemberProfileResponse(
+                member.getId(),
+                member.getEmail().address(),
+                member.getNickname(),
+                member.getDetail().getProfile() != null ? 
+                    member.getDetail().getProfile().address() : null
+        );
+    }
+}

--- a/src/main/java/dooya/see/application/member/AuthService.java
+++ b/src/main/java/dooya/see/application/member/AuthService.java
@@ -19,16 +19,23 @@ public class AuthService implements MemberAuth {
 
         Member member = memberFinder.findByEmail(email);
 
-        if (!member.verifyPassword(loginRequest.password(), passwordEncoder)) {
-            throw new AuthenticateException("비밀번호가 일치하지 않습니다");
-        }
-
-        if (member.getStatus() == MemberStatus.DEACTIVATED) {
-            throw new AuthenticateException("비활성화된 계정입니다");
-        }
+        validatePassword(loginRequest, member);
+        validateAccountStatus(member);
 
         String token = "abc";
 
         return new LoginResult(member, token);
+    }
+
+    private void validatePassword(LoginRequest loginRequest, Member member) {
+        if (!member.verifyPassword(loginRequest.password(), passwordEncoder)) {
+            throw new AuthenticateException("비밀번호가 일치하지 않습니다");
+        }
+    }
+
+    private static void validateAccountStatus(Member member) {
+        if (member.getStatus() == MemberStatus.DEACTIVATED) {
+            throw new AuthenticateException("비활성화된 계정입니다");
+        }
     }
 }

--- a/src/main/java/dooya/see/application/member/AuthService.java
+++ b/src/main/java/dooya/see/application/member/AuthService.java
@@ -1,0 +1,34 @@
+package dooya.see.application.member;
+
+import dooya.see.application.member.provided.MemberAuth;
+import dooya.see.application.member.provided.MemberFinder;
+import dooya.see.domain.member.*;
+import dooya.see.domain.shared.Email;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService implements MemberAuth {
+    private final MemberFinder memberFinder;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    public LoginResult login(LoginRequest loginRequest) {
+        Email email = new Email(loginRequest.email());
+
+        Member member = memberFinder.findByEmail(email);
+
+        if (!member.verifyPassword(loginRequest.password(), passwordEncoder)) {
+            throw new AuthenticateException("비밀번호가 일치하지 않습니다");
+        }
+
+        if (member.getStatus() == MemberStatus.DEACTIVATED) {
+            throw new AuthenticateException("비활성화된 계정입니다");
+        }
+
+        String token = "abc";
+
+        return new LoginResult(member, token);
+    }
+}

--- a/src/main/java/dooya/see/application/member/AuthService.java
+++ b/src/main/java/dooya/see/application/member/AuthService.java
@@ -2,6 +2,7 @@ package dooya.see.application.member;
 
 import dooya.see.application.member.provided.MemberAuth;
 import dooya.see.application.member.provided.MemberFinder;
+import dooya.see.application.member.required.TokenManager;
 import dooya.see.domain.member.*;
 import dooya.see.domain.shared.Email;
 import lombok.RequiredArgsConstructor;
@@ -12,6 +13,7 @@ import org.springframework.stereotype.Service;
 public class AuthService implements MemberAuth {
     private final MemberFinder memberFinder;
     private final PasswordEncoder passwordEncoder;
+    private final TokenManager tokenManager;
 
     @Override
     public LoginResult login(LoginRequest loginRequest) {
@@ -22,7 +24,7 @@ public class AuthService implements MemberAuth {
         validatePassword(loginRequest, member);
         validateAccountStatus(member);
 
-        String token = "abc";
+        String token = tokenManager.generateToken(member);
 
         return new LoginResult(member, token);
     }

--- a/src/main/java/dooya/see/application/member/MemberAuthService.java
+++ b/src/main/java/dooya/see/application/member/MemberAuthService.java
@@ -10,18 +10,18 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-public class AuthService implements MemberAuth {
+public class MemberAuthService implements MemberAuth {
     private final MemberFinder memberFinder;
     private final PasswordEncoder passwordEncoder;
     private final TokenManager tokenManager;
 
     @Override
-    public LoginResult login(LoginRequest loginRequest) {
-        Email email = new Email(loginRequest.email());
+    public LoginResult login(MemberAuthRequest memberAuthRequest) {
+        Email email = new Email(memberAuthRequest.email());
 
         Member member = memberFinder.findByEmail(email);
 
-        validatePassword(loginRequest, member);
+        validatePassword(memberAuthRequest, member);
         validateAccountStatus(member);
 
         String token = tokenManager.generateToken(member);
@@ -29,8 +29,8 @@ public class AuthService implements MemberAuth {
         return new LoginResult(member, token);
     }
 
-    private void validatePassword(LoginRequest loginRequest, Member member) {
-        if (!member.verifyPassword(loginRequest.password(), passwordEncoder)) {
+    private void validatePassword(MemberAuthRequest memberAuthRequest, Member member) {
+        if (!member.verifyPassword(memberAuthRequest.password(), passwordEncoder)) {
             throw new AuthenticateException("비밀번호가 일치하지 않습니다");
         }
     }

--- a/src/main/java/dooya/see/application/member/MemberAuthService.java
+++ b/src/main/java/dooya/see/application/member/MemberAuthService.java
@@ -31,7 +31,7 @@ public class MemberAuthService implements MemberAuth {
 
     private void validatePassword(MemberAuthRequest memberAuthRequest, Member member) {
         if (!member.verifyPassword(memberAuthRequest.password(), passwordEncoder)) {
-            throw new AuthenticateException("비밀번호가 일치하지 않습니다");
+            throw new AuthenticateException("이메일 또는 비밀번호가 일치하지 않습니다");
         }
     }
 

--- a/src/main/java/dooya/see/application/member/MemberAuthService.java
+++ b/src/main/java/dooya/see/application/member/MemberAuthService.java
@@ -17,9 +17,7 @@ public class MemberAuthService implements MemberAuth {
 
     @Override
     public LoginResult login(MemberAuthRequest memberAuthRequest) {
-        Email email = new Email(memberAuthRequest.email());
-
-        Member member = memberFinder.findByEmail(email);
+        Member member = memberFinder.findByEmail(new Email(memberAuthRequest.email()));
 
         validatePassword(memberAuthRequest, member);
         validateAccountStatus(member);
@@ -27,6 +25,11 @@ public class MemberAuthService implements MemberAuth {
         String token = tokenManager.generateToken(member);
 
         return new LoginResult(member, token);
+    }
+
+    @Override
+    public Member getCurrentMember(String token) {
+        return memberFinder.findByEmail(new Email(tokenManager.extractEmailFromToken(token)));
     }
 
     private void validatePassword(MemberAuthRequest memberAuthRequest, Member member) {

--- a/src/main/java/dooya/see/application/member/MemberQueryService.java
+++ b/src/main/java/dooya/see/application/member/MemberQueryService.java
@@ -3,6 +3,7 @@ package dooya.see.application.member;
 import dooya.see.application.member.provided.MemberFinder;
 import dooya.see.application.member.required.MemberRepository;
 import dooya.see.domain.member.Member;
+import dooya.see.domain.shared.Email;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,6 +16,11 @@ public class MemberQueryService implements MemberFinder {
 
     @Override
     public Member find(Long memberId) {
-        return memberRepository.findById(memberId).orElseThrow(() -> new IllegalArgumentException("회원을 찾을 수 없스니다"));
+        return memberRepository.findById(memberId).orElseThrow(() -> new IllegalArgumentException("회원을 찾을 수 없습니다"));
+    }
+
+    @Override
+    public Member findByEmail(Email email) {
+        return memberRepository.findByEmail(email).orElseThrow(() -> new IllegalArgumentException("회원을 찾을 수 없습니다"));
     }
 }

--- a/src/main/java/dooya/see/application/member/MemberQueryService.java
+++ b/src/main/java/dooya/see/application/member/MemberQueryService.java
@@ -3,6 +3,7 @@ package dooya.see.application.member;
 import dooya.see.application.member.provided.MemberFinder;
 import dooya.see.application.member.required.MemberRepository;
 import dooya.see.domain.member.Member;
+import dooya.see.domain.member.MemberNotFoundException;
 import dooya.see.domain.shared.Email;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -16,11 +17,11 @@ public class MemberQueryService implements MemberFinder {
 
     @Override
     public Member find(Long memberId) {
-        return memberRepository.findById(memberId).orElseThrow(() -> new IllegalArgumentException("회원을 찾을 수 없습니다"));
+        return memberRepository.findById(memberId).orElseThrow(() -> new MemberNotFoundException("회원을 찾을 수 없습니다"));
     }
 
     @Override
     public Member findByEmail(Email email) {
-        return memberRepository.findByEmail(email).orElseThrow(() -> new IllegalArgumentException("회원을 찾을 수 없습니다"));
+        return memberRepository.findByEmail(email).orElseThrow(() -> new MemberNotFoundException("회원을 찾을 수 없습니다"));
     }
 }

--- a/src/main/java/dooya/see/application/member/provided/MemberAuth.java
+++ b/src/main/java/dooya/see/application/member/provided/MemberAuth.java
@@ -1,8 +1,11 @@
 package dooya.see.application.member.provided;
 
+import dooya.see.domain.member.Member;
 import dooya.see.domain.member.MemberAuthRequest;
 import dooya.see.domain.member.LoginResult;
 
 public interface MemberAuth {
     LoginResult login(MemberAuthRequest memberAuthRequest);
+
+    Member getCurrentMember(String token);
 }

--- a/src/main/java/dooya/see/application/member/provided/MemberAuth.java
+++ b/src/main/java/dooya/see/application/member/provided/MemberAuth.java
@@ -1,0 +1,8 @@
+package dooya.see.application.member.provided;
+
+import dooya.see.domain.member.LoginRequest;
+import dooya.see.domain.member.LoginResult;
+
+public interface MemberAuth {
+    LoginResult login(LoginRequest loginRequest);
+}

--- a/src/main/java/dooya/see/application/member/provided/MemberAuth.java
+++ b/src/main/java/dooya/see/application/member/provided/MemberAuth.java
@@ -1,8 +1,8 @@
 package dooya.see.application.member.provided;
 
-import dooya.see.domain.member.LoginRequest;
+import dooya.see.domain.member.MemberAuthRequest;
 import dooya.see.domain.member.LoginResult;
 
 public interface MemberAuth {
-    LoginResult login(LoginRequest loginRequest);
+    LoginResult login(MemberAuthRequest memberAuthRequest);
 }

--- a/src/main/java/dooya/see/application/member/provided/MemberFinder.java
+++ b/src/main/java/dooya/see/application/member/provided/MemberFinder.java
@@ -1,7 +1,10 @@
 package dooya.see.application.member.provided;
 
 import dooya.see.domain.member.Member;
+import dooya.see.domain.shared.Email;
 
 public interface MemberFinder {
     Member find(Long memberId);
+
+    Member findByEmail(Email email);
 }

--- a/src/main/java/dooya/see/application/member/required/TokenManager.java
+++ b/src/main/java/dooya/see/application/member/required/TokenManager.java
@@ -8,7 +8,5 @@ public interface TokenManager {
 
     Claims parseToken(String token);
 
-    boolean isTokenValid(String token);
-
     String extractEmailFromToken(String token);
 }

--- a/src/main/java/dooya/see/application/member/required/TokenManager.java
+++ b/src/main/java/dooya/see/application/member/required/TokenManager.java
@@ -1,0 +1,14 @@
+package dooya.see.application.member.required;
+
+import dooya.see.domain.member.Member;
+import io.jsonwebtoken.Claims;
+
+public interface TokenManager {
+    String generateToken(Member member);
+
+    Claims parseToken(String token);
+
+    boolean isTokenValid(String token);
+
+    String extractEmailFromToken(String token);
+}

--- a/src/main/java/dooya/see/application/member/required/TokenManager.java
+++ b/src/main/java/dooya/see/application/member/required/TokenManager.java
@@ -1,12 +1,9 @@
 package dooya.see.application.member.required;
 
 import dooya.see.domain.member.Member;
-import io.jsonwebtoken.Claims;
 
 public interface TokenManager {
     String generateToken(Member member);
-
-    Claims parseToken(String token);
 
     String extractEmailFromToken(String token);
 }

--- a/src/main/java/dooya/see/domain/member/AuthenticateException.java
+++ b/src/main/java/dooya/see/domain/member/AuthenticateException.java
@@ -1,0 +1,7 @@
+package dooya.see.domain.member;
+
+public class AuthenticateException extends RuntimeException {
+    public AuthenticateException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/dooya/see/domain/member/LoginRequest.java
+++ b/src/main/java/dooya/see/domain/member/LoginRequest.java
@@ -1,0 +1,10 @@
+package dooya.see.domain.member;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record LoginRequest(
+        @Email String email,
+        @NotBlank String password
+) {
+}

--- a/src/main/java/dooya/see/domain/member/LoginResult.java
+++ b/src/main/java/dooya/see/domain/member/LoginResult.java
@@ -1,0 +1,7 @@
+package dooya.see.domain.member;
+
+public record LoginResult(
+        Member member,
+        String accessToken
+) {
+}

--- a/src/main/java/dooya/see/domain/member/MemberAuthRequest.java
+++ b/src/main/java/dooya/see/domain/member/MemberAuthRequest.java
@@ -3,7 +3,7 @@ package dooya.see.domain.member;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 
-public record LoginRequest(
+public record MemberAuthRequest(
         @Email String email,
         @NotBlank String password
 ) {

--- a/src/main/java/dooya/see/domain/member/MemberNotFoundException.java
+++ b/src/main/java/dooya/see/domain/member/MemberNotFoundException.java
@@ -1,0 +1,7 @@
+package dooya.see.domain.member;
+
+public class MemberNotFoundException extends RuntimeException {
+    public MemberNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/test/java/dooya/see/adapter/security/JwtTokenManagerTest.java
+++ b/src/test/java/dooya/see/adapter/security/JwtTokenManagerTest.java
@@ -1,0 +1,39 @@
+package dooya.see.adapter.security;
+
+import dooya.see.application.member.provided.MemberRegister;
+import dooya.see.application.member.required.TokenManager;
+import dooya.see.domain.member.AuthenticateException;
+import dooya.see.domain.member.Member;
+import io.jsonwebtoken.Claims;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static dooya.see.domain.member.MemberFixture.createMemberRegisterRequest;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+record JwtTokenManagerTest(MemberRegister memberRegister, TokenManager tokenManager) {
+    @Test
+    @DisplayName("회원 정보로 JWT 토큰 생성 후 파싱하면 동일한 회원 정보를 얻을 수 있다")
+    void generateAndParseToken() {
+        Member member = memberRegister.register(createMemberRegisterRequest());
+
+        String token = tokenManager.generateToken(member);
+        Claims claims = tokenManager.parseToken(token);
+
+        assertThat(claims.getSubject()).isEqualTo(member.getEmail().address());
+        assertThat(claims.get("memberId", Long.class)).isEqualTo(member.getId());
+        assertThat(claims.get("nickname", String.class)).isEqualTo(member.getNickname());
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 JWT 토큰 파싱 시 인증 예외가 발생한다")
+    void parseInvalidToken() {
+        String invalidToken = "invalid.jwt.token";
+
+        assertThatThrownBy(() -> tokenManager.parseToken(invalidToken))
+            .isInstanceOf(AuthenticateException.class);
+    }
+}

--- a/src/test/java/dooya/see/adapter/security/JwtTokenManagerTest.java
+++ b/src/test/java/dooya/see/adapter/security/JwtTokenManagerTest.java
@@ -20,9 +20,9 @@ record JwtTokenManagerTest(MemberRegister memberRegister, TokenManager tokenMana
         Member member = memberRegister.register(createMemberRegisterRequest());
 
         String token = tokenManager.generateToken(member);
-        token = tokenManager.extractEmailFromToken(token);
+        String email = tokenManager.extractEmailFromToken(token);
 
-        assertThat(token).isNotNull();
+        assertThat(email).isEqualTo(member.getEmail().address());
     }
 
     @Test

--- a/src/test/java/dooya/see/adapter/security/JwtTokenManagerTest.java
+++ b/src/test/java/dooya/see/adapter/security/JwtTokenManagerTest.java
@@ -4,7 +4,6 @@ import dooya.see.application.member.provided.MemberRegister;
 import dooya.see.application.member.required.TokenManager;
 import dooya.see.domain.member.AuthenticateException;
 import dooya.see.domain.member.Member;
-import io.jsonwebtoken.Claims;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -21,11 +20,9 @@ record JwtTokenManagerTest(MemberRegister memberRegister, TokenManager tokenMana
         Member member = memberRegister.register(createMemberRegisterRequest());
 
         String token = tokenManager.generateToken(member);
-        Claims claims = tokenManager.parseToken(token);
+        token = tokenManager.extractEmailFromToken(token);
 
-        assertThat(claims.getSubject()).isEqualTo(member.getEmail().address());
-        assertThat(claims.get("memberId", Long.class)).isEqualTo(member.getId());
-        assertThat(claims.get("nickname", String.class)).isEqualTo(member.getNickname());
+        assertThat(token).isNotNull();
     }
 
     @Test
@@ -33,7 +30,7 @@ record JwtTokenManagerTest(MemberRegister memberRegister, TokenManager tokenMana
     void parseInvalidToken() {
         String invalidToken = "invalid.jwt.token";
 
-        assertThatThrownBy(() -> tokenManager.parseToken(invalidToken))
+        assertThatThrownBy(() -> tokenManager.extractEmailFromToken(invalidToken))
             .isInstanceOf(AuthenticateException.class);
     }
 }

--- a/src/test/java/dooya/see/adapter/webapi/MemberApiTest.java
+++ b/src/test/java/dooya/see/adapter/webapi/MemberApiTest.java
@@ -3,6 +3,7 @@ package dooya.see.adapter.webapi;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dooya.see.adapter.webapi.dto.MemberAuthResponse;
+import dooya.see.adapter.webapi.dto.MemberProfileResponse;
 import dooya.see.adapter.webapi.dto.MemberRegisterResponse;
 import dooya.see.application.member.provided.MemberRegister;
 import dooya.see.application.member.required.MemberRepository;
@@ -129,6 +130,67 @@ class MemberApiTest {
 
         MvcTestResult result = mvcTester.post().uri("/api/members/login").contentType(MediaType.APPLICATION_JSON)
                 .content(requestJson).exchange();
+
+        assertThat(result)
+                .apply(print())
+                .hasStatus(HttpStatus.UNAUTHORIZED);
+    }
+
+    @Test
+    @DisplayName("유효한 액세스 토큰으로 현재 회원 정보 조회 시 회원 정보를 반환한다")
+    void getCurrentMember() throws JsonProcessingException, UnsupportedEncodingException {
+        memberRegister.register(createMemberRegisterRequest());
+
+        MemberAuthRequest request = createMemberAuthRequest();
+        String requestJson = objectMapper.writeValueAsString(request);
+
+        MvcTestResult loginResult = mvcTester.post().uri("/api/members/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestJson).exchange();
+
+        MemberAuthResponse authResponse =
+                objectMapper.readValue(loginResult.getResponse().getContentAsString(), MemberAuthResponse.class);
+
+        MvcTestResult getCurrentMemberResult = mvcTester.get().uri("/api/members/my")
+                .header("Authorization", "Bearer " + authResponse.accessToken())
+                .exchange();
+
+        MemberProfileResponse profileResponse =
+                objectMapper.readValue(getCurrentMemberResult.getResponse().getContentAsString(), MemberProfileResponse.class);
+
+        Member member = memberRepository.findById(profileResponse.memberId()).orElseThrow();
+
+        assertThat(member.getId()).isEqualTo(profileResponse.memberId());
+    }
+
+    @Test
+    @DisplayName("Authorization 헤더 없이 현재 회원 정보 조회 시 401 Unauthorized 상태 코드를 반환한다")
+    void getCurrentMemberFailWithoutAuthorizationHeader() {
+        MvcTestResult result = mvcTester.get().uri("/api/members/my").exchange();
+
+        assertThat(result)
+                .apply(print())
+                .hasStatus(HttpStatus.UNAUTHORIZED);
+    }
+
+    @Test
+    @DisplayName("잘못된 형식의 Authorization 헤더로 현재 회원 정보 조회 시 401 Unauthorized 상태 코드를 반환한다")
+    void getCurrentMemberFailWithInvalidAuthorizationHeader() {
+        MvcTestResult result = mvcTester.get().uri("/api/members/my")
+                .header("Authorization", "InvalidTokenFormat")
+                .exchange();
+
+        assertThat(result)
+                .apply(print())
+                .hasStatus(HttpStatus.UNAUTHORIZED);
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 토큰으로 현재 회원 정보 조회 시 401 Unauthorized 상태 코드를 반환한다")
+    void getCurrentMemberFailWithInvalidToken() {
+        MvcTestResult result = mvcTester.get().uri("/api/members/my")
+                .header("Authorization", "Bearer invalidToken")
+                .exchange();
 
         assertThat(result)
                 .apply(print())

--- a/src/test/java/dooya/see/adapter/webapi/MemberApiTest.java
+++ b/src/test/java/dooya/see/adapter/webapi/MemberApiTest.java
@@ -2,9 +2,11 @@ package dooya.see.adapter.webapi;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import dooya.see.adapter.webapi.dto.MemberAuthResponse;
 import dooya.see.adapter.webapi.dto.MemberRegisterResponse;
 import dooya.see.application.member.provided.MemberRegister;
 import dooya.see.application.member.required.MemberRepository;
+import dooya.see.domain.member.MemberAuthRequest;
 import dooya.see.domain.member.Member;
 import dooya.see.domain.member.MemberRegisterRequest;
 import dooya.see.domain.member.MemberStatus;
@@ -74,5 +76,62 @@ class MemberApiTest {
         assertThat(result)
                 .apply(print())
                 .hasStatus(HttpStatus.CONFLICT);
+    }
+
+    @Test
+    @DisplayName("올바른 회원 정보로 로그인 시 회원 ID와 액세스 토큰이 포함된 응답을 반환한다")
+    void login() throws JsonProcessingException, UnsupportedEncodingException {
+        memberRegister.register(createMemberRegisterRequest());
+
+        MemberAuthRequest request = createMemberAuthRequest();
+        String requestJson = objectMapper.writeValueAsString(request);
+
+        MvcTestResult result = mvcTester.post().uri("/api/members/login").contentType(MediaType.APPLICATION_JSON)
+                .content(requestJson).exchange();
+
+        assertThat(result)
+                .hasStatusOk()
+                .bodyJson()
+                .hasPathSatisfying("$.email", value -> assertThat(value).isEqualTo(request.email()));
+
+        MemberAuthResponse response =
+                objectMapper.readValue(result.getResponse().getContentAsString(), MemberAuthResponse.class);
+
+        Member member = memberRepository.findById(response.memberId()).orElseThrow();
+
+        assertThat(member.getEmail().address()).isEqualTo(request.email());
+        assertThat(response.accessToken()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 이메일로 로그인 시도 시 404 Not Found 상태 코드를 반환한다")
+    void loginFailWithWrongEmail() throws JsonProcessingException {
+        memberRegister.register(createMemberRegisterRequest());
+
+        MemberAuthRequest request = createMemberAuthRequest("wrong@see.com");
+        String requestJson = objectMapper.writeValueAsString(request);
+
+        MvcTestResult result = mvcTester.post().uri("/api/members/login").contentType(MediaType.APPLICATION_JSON)
+                .content(requestJson).exchange();
+
+        assertThat(result)
+                .apply(print())
+                .hasStatus(HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("잘못된 비밀번호로 로그인 시도 시 401 Unauthorized 상태 코드를 반환한다")
+    void loginFailWithWrongPassword() throws JsonProcessingException {
+        memberRegister.register(createMemberRegisterRequest());
+
+        MemberAuthRequest request = createAuthRequestWithPassword("wrongPassword");
+        String requestJson = objectMapper.writeValueAsString(request);
+
+        MvcTestResult result = mvcTester.post().uri("/api/members/login").contentType(MediaType.APPLICATION_JSON)
+                .content(requestJson).exchange();
+
+        assertThat(result)
+                .apply(print())
+                .hasStatus(HttpStatus.UNAUTHORIZED);
     }
 }

--- a/src/test/java/dooya/see/application/member/provided/MemberAuthTest.java
+++ b/src/test/java/dooya/see/application/member/provided/MemberAuthTest.java
@@ -13,7 +13,6 @@ import org.springframework.context.annotation.Import;
 import org.springframework.transaction.annotation.Transactional;
 
 import static dooya.see.domain.member.MemberFixture.*;
-import static dooya.see.domain.member.MemberFixture.createMemberAuthRequest;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -55,6 +54,31 @@ record MemberAuthTest(MemberRegister memberRegister, MemberAuth memberAuth, Enti
         memberRegister.deactivate(member.getId());
 
         assertThatThrownBy(() -> memberAuth.login(MemberFixture.createMemberAuthRequest()))
+            .isInstanceOf(AuthenticateException.class);
+    }
+
+    @Test
+    @DisplayName("유효한 액세스 토큰으로 현재 로그인된 회원 정보를 조회한다")
+    void getCurrentMember() {
+        memberRegister.register(createMemberRegisterRequest());
+        entityManager.flush();
+        entityManager.clear();
+
+        LoginResult loginResult = memberAuth.login(MemberFixture.createMemberAuthRequest());
+
+        Member member = memberAuth.getCurrentMember(loginResult.accessToken());
+
+        assertThat(member.getId()).isEqualTo(loginResult.member().getId());
+    }
+
+    @Test
+    @DisplayName("잘못된 액세스 토큰으로 회원 정보 조회 시 인증 예외가 발생한다")
+    void getCurrentMemberFailWithInvalidToken() {
+        memberRegister.register(createMemberRegisterRequest());
+        entityManager.flush();
+        entityManager.clear();
+        
+        assertThatThrownBy(() -> memberAuth.getCurrentMember("invalidToken"))
             .isInstanceOf(AuthenticateException.class);
     }
 }

--- a/src/test/java/dooya/see/application/member/provided/MemberAuthTest.java
+++ b/src/test/java/dooya/see/application/member/provided/MemberAuthTest.java
@@ -1,0 +1,32 @@
+package dooya.see.application.member.provided;
+
+import dooya.see.SeeTestConfiguration;
+import dooya.see.domain.member.LoginResult;
+import dooya.see.domain.member.Member;
+import dooya.see.domain.member.MemberFixture;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+@Import(SeeTestConfiguration.class)
+record MemberAuthTest(MemberRegister memberRegister, MemberFinder memberFinder, MemberAuth memberAuth, EntityManager entityManager) {
+    @Test
+    @DisplayName("")
+    void login() {
+        Member member = memberRegister.register(MemberFixture.createMemberRegisterRequest());
+        entityManager.flush();
+        entityManager.clear();
+
+        LoginResult loginResult = memberAuth.login(MemberFixture.createLoginRequest());
+
+        assertThat(loginResult.member().getId()).isEqualTo(member.getId());
+        assertThat(loginResult.accessToken()).isNotNull();
+    }
+}

--- a/src/test/java/dooya/see/application/member/provided/MemberAuthTest.java
+++ b/src/test/java/dooya/see/application/member/provided/MemberAuthTest.java
@@ -1,9 +1,9 @@
 package dooya.see.application.member.provided;
 
 import dooya.see.SeeTestConfiguration;
+import dooya.see.domain.member.AuthenticateException;
 import dooya.see.domain.member.LoginResult;
 import dooya.see.domain.member.Member;
-import dooya.see.domain.member.MemberFixture;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -11,22 +11,49 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.transaction.annotation.Transactional;
 
+import static dooya.see.domain.member.MemberFixture.*;
+import static dooya.see.domain.member.MemberFixture.createLoginRequest;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SpringBootTest
 @Transactional
 @Import(SeeTestConfiguration.class)
-record MemberAuthTest(MemberRegister memberRegister, MemberFinder memberFinder, MemberAuth memberAuth, EntityManager entityManager) {
+record MemberAuthTest(MemberRegister memberRegister, MemberAuth memberAuth, EntityManager entityManager) {
     @Test
     @DisplayName("")
     void login() {
-        Member member = memberRegister.register(MemberFixture.createMemberRegisterRequest());
+        Member member = memberRegister.register(createMemberRegisterRequest());
         entityManager.flush();
         entityManager.clear();
 
-        LoginResult loginResult = memberAuth.login(MemberFixture.createLoginRequest());
+        LoginResult loginResult = memberAuth.login(createLoginRequest());
 
         assertThat(loginResult.member().getId()).isEqualTo(member.getId());
         assertThat(loginResult.accessToken()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("")
+    void passwordNotMatheLoginFail() {
+        memberRegister.register(createMemberRegisterRequest());
+        entityManager.flush();
+        entityManager.clear();
+
+        assertThatThrownBy(() -> memberAuth.login(createLoginRequestWithPassword("fakepassword")))
+            .isInstanceOf(AuthenticateException.class);
+    }
+
+    @Test
+    @DisplayName("")
+    void no() {
+        Member member = memberRegister.register(createMemberRegisterRequest());
+        entityManager.flush();
+        entityManager.clear();
+
+        memberRegister.deactivate(member.getId());
+
+        assertThatThrownBy(() -> memberAuth.login(createLoginRequest()))
+            .isInstanceOf(AuthenticateException.class);
     }
 }

--- a/src/test/java/dooya/see/application/member/provided/MemberAuthTest.java
+++ b/src/test/java/dooya/see/application/member/provided/MemberAuthTest.java
@@ -21,7 +21,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 @Import(SeeTestConfiguration.class)
 record MemberAuthTest(MemberRegister memberRegister, MemberAuth memberAuth, EntityManager entityManager) {
     @Test
-    @DisplayName("")
+    @DisplayName("올바른 이메일과 비밀번호로 로그인 시 회원 정보와 액세스 토큰을 반환한다")
     void login() {
         Member member = memberRegister.register(createMemberRegisterRequest());
         entityManager.flush();
@@ -34,8 +34,8 @@ record MemberAuthTest(MemberRegister memberRegister, MemberAuth memberAuth, Enti
     }
 
     @Test
-    @DisplayName("")
-    void passwordNotMatheLoginFail() {
+    @DisplayName("잘못된 비밀번호로 로그인 시도 시 인증 예외가 발생한다")
+    void loginFailWithWrongPassword() {
         memberRegister.register(createMemberRegisterRequest());
         entityManager.flush();
         entityManager.clear();
@@ -45,8 +45,8 @@ record MemberAuthTest(MemberRegister memberRegister, MemberAuth memberAuth, Enti
     }
 
     @Test
-    @DisplayName("")
-    void no() {
+    @DisplayName("비활성화된 계정으로 로그인 시도 시 인증 예외가 발생한다")
+    void loginFailWithDeactivatedAccount() {
         Member member = memberRegister.register(createMemberRegisterRequest());
         entityManager.flush();
         entityManager.clear();

--- a/src/test/java/dooya/see/application/member/provided/MemberAuthTest.java
+++ b/src/test/java/dooya/see/application/member/provided/MemberAuthTest.java
@@ -4,6 +4,7 @@ import dooya.see.SeeTestConfiguration;
 import dooya.see.domain.member.AuthenticateException;
 import dooya.see.domain.member.LoginResult;
 import dooya.see.domain.member.Member;
+import dooya.see.domain.member.MemberFixture;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -12,7 +13,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.transaction.annotation.Transactional;
 
 import static dooya.see.domain.member.MemberFixture.*;
-import static dooya.see.domain.member.MemberFixture.createLoginRequest;
+import static dooya.see.domain.member.MemberFixture.createMemberAuthRequest;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -27,7 +28,7 @@ record MemberAuthTest(MemberRegister memberRegister, MemberAuth memberAuth, Enti
         entityManager.flush();
         entityManager.clear();
 
-        LoginResult loginResult = memberAuth.login(createLoginRequest());
+        LoginResult loginResult = memberAuth.login(MemberFixture.createMemberAuthRequest());
 
         assertThat(loginResult.member().getId()).isEqualTo(member.getId());
         assertThat(loginResult.accessToken()).isNotNull();
@@ -40,7 +41,7 @@ record MemberAuthTest(MemberRegister memberRegister, MemberAuth memberAuth, Enti
         entityManager.flush();
         entityManager.clear();
 
-        assertThatThrownBy(() -> memberAuth.login(createLoginRequestWithPassword("fakepassword")))
+        assertThatThrownBy(() -> memberAuth.login(createAuthRequestWithPassword("fakepassword")))
             .isInstanceOf(AuthenticateException.class);
     }
 
@@ -53,7 +54,7 @@ record MemberAuthTest(MemberRegister memberRegister, MemberAuth memberAuth, Enti
 
         memberRegister.deactivate(member.getId());
 
-        assertThatThrownBy(() -> memberAuth.login(createLoginRequest()))
+        assertThatThrownBy(() -> memberAuth.login(MemberFixture.createMemberAuthRequest()))
             .isInstanceOf(AuthenticateException.class);
     }
 }

--- a/src/test/java/dooya/see/application/member/provided/MemberFinderTest.java
+++ b/src/test/java/dooya/see/application/member/provided/MemberFinderTest.java
@@ -2,6 +2,7 @@ package dooya.see.application.member.provided;
 
 import dooya.see.SeeTestConfiguration;
 import dooya.see.domain.member.Member;
+import dooya.see.domain.member.MemberNotFoundException;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -33,6 +34,6 @@ record MemberFinderTest(MemberFinder memberFinder, MemberRegister memberRegister
     @DisplayName("존재하지 않는 ID로 조회 시 예외가 발생한다")
     void findFail() {
         assertThatThrownBy(() -> memberFinder.find(999L))
-            .isInstanceOf(IllegalArgumentException.class);
+            .isInstanceOf(MemberNotFoundException.class);
     }
 }

--- a/src/test/java/dooya/see/domain/member/MemberFixture.java
+++ b/src/test/java/dooya/see/domain/member/MemberFixture.java
@@ -22,4 +22,8 @@ public class MemberFixture {
             }
         };
     }
+
+    public static LoginRequest createLoginRequest() {
+        return new LoginRequest("dooya@see.com", "longSecret");
+    }
 }

--- a/src/test/java/dooya/see/domain/member/MemberFixture.java
+++ b/src/test/java/dooya/see/domain/member/MemberFixture.java
@@ -23,19 +23,19 @@ public class MemberFixture {
         };
     }
 
-    public static LoginRequest createLoginRequest() {
-        return createLoginRequest("dooya@see.com");
+    public static MemberAuthRequest createMemberAuthRequest() {
+        return createMemberAuthRequest("dooya@see.com");
     }
 
-    public static LoginRequest createLoginRequest(String email) {
-        return createLoginRequest(email, "longSecret");
+    public static MemberAuthRequest createMemberAuthRequest(String email) {
+        return createMemberAuthRequest(email, "longSecret");
     }
 
-    public static LoginRequest createLoginRequest(String email, String password) {
-        return new LoginRequest(email, password);
+    public static MemberAuthRequest createMemberAuthRequest(String email, String password) {
+        return new MemberAuthRequest(email, password);
     }
 
-    public static LoginRequest createLoginRequestWithPassword(String password) {
-        return createLoginRequest("dooya@see.com", password);
+    public static MemberAuthRequest createAuthRequestWithPassword(String password) {
+        return createMemberAuthRequest("dooya@see.com", password);
     }
 }

--- a/src/test/java/dooya/see/domain/member/MemberFixture.java
+++ b/src/test/java/dooya/see/domain/member/MemberFixture.java
@@ -24,6 +24,18 @@ public class MemberFixture {
     }
 
     public static LoginRequest createLoginRequest() {
-        return new LoginRequest("dooya@see.com", "longSecret");
+        return createLoginRequest("dooya@see.com");
+    }
+
+    public static LoginRequest createLoginRequest(String email) {
+        return createLoginRequest(email, "longSecret");
+    }
+
+    public static LoginRequest createLoginRequest(String email, String password) {
+        return new LoginRequest(email, password);
+    }
+
+    public static LoginRequest createLoginRequestWithPassword(String password) {
+        return createLoginRequest("dooya@see.com", password);
     }
 }


### PR DESCRIPTION
## 📌 Issue

<!-- 해결하려는 이슈 번호나 주제를 명확하게 적어주세요. -->

- closed #102 

---

## 🧐 현재 상황

<!-- 현재 발생한 문제, 개선이 필요한 사항을 간략히 설명해주세요. -->

- 로그인 기능 구현이 필요

---

## 🎯 목표

<!-- 이슈를 통해 달성하고자 하는 목표를 설명해주세요. -->

- 로그인, 로그인 후 토큰으로 회원 조회 기능

---

## 🛠 작업 내용

- 작업 할 내용을 입력해주세요.

- [x] Member 도메인 로그인 기능 구현
- [x] 테스트 작성

---

## 🚀 기타 사항

<!-- 리뷰어가 추가적으로 알아야 할 사항이 있다면 기재해주세요. -->

- 추가적인 내용을 작성해주세요.(참고 자료, 협업 내용)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 이메일/비밀번호 로그인 API 추가: 로그인 성공 시 JWT 액세스 토큰 발급
  - 내 프로필 조회 API 추가: Authorization Bearer 토큰으로 현재 회원 정보 반환
- Bug Fixes
  - 미존재 회원 조회 시 404 Not Found 반환
  - 인증 실패 시 401 Unauthorized 및 명확한 오류 응답 제공
- Tests
  - 로그인·프로필 조회 및 토큰 생성/검증 관련 통합 테스트 추가
- Chores
  - JWT 관련 라이브러리 의존성 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->