### PR TITLE
Member Primary Adapter 기능 추가 (탈퇴, 정보수정)

### DIFF
--- a/src/main/java/dooya/see/adapter/webapi/MemberApi.java
+++ b/src/main/java/dooya/see/adapter/webapi/MemberApi.java
@@ -8,7 +8,6 @@ import dooya.see.application.member.provided.MemberRegister;
 import dooya.see.domain.member.*;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.http.HttpHeaders;
 

--- a/src/main/java/dooya/see/adapter/webapi/MemberApi.java
+++ b/src/main/java/dooya/see/adapter/webapi/MemberApi.java
@@ -8,6 +8,7 @@ import dooya.see.application.member.provided.MemberRegister;
 import dooya.see.domain.member.*;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.http.HttpHeaders;
 
@@ -37,6 +38,14 @@ public class MemberApi {
         Member member = memberAuth.getCurrentMember(token);
 
         return MemberProfileResponse.from(member);
+    }
+
+    @PatchMapping("/api/members/my/deactivate")
+    public void deactivate(@RequestHeader(value = HttpHeaders.AUTHORIZATION, required = false) String authorizationHeader) {
+        String token = extractTokenFromHeader(authorizationHeader);
+        Member member = memberAuth.getCurrentMember(token);
+
+        memberRegister.deactivate(member.getId());
     }
 
     private String extractTokenFromHeader(String authorizationHeader) {

--- a/src/main/java/dooya/see/adapter/webapi/MemberApi.java
+++ b/src/main/java/dooya/see/adapter/webapi/MemberApi.java
@@ -48,6 +48,17 @@ public class MemberApi {
         memberRegister.deactivate(member.getId());
     }
 
+    @PutMapping("/api/members/my/updateInfo")
+    public MemberProfileResponse updateInfo(@RequestHeader(value = HttpHeaders.AUTHORIZATION, required = false) String authorizationHeader,
+                                            @RequestBody @Valid MemberInfoUpdateRequest request) {
+        String token = extractTokenFromHeader(authorizationHeader);
+        Member currentMember = memberAuth.getCurrentMember(token);
+
+        Member updatedMember = memberRegister.updateInfo(currentMember.getId(), request);
+
+        return MemberProfileResponse.from(updatedMember);
+    }
+
     private String extractTokenFromHeader(String authorizationHeader) {
         if (authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {
             throw new AuthenticateException("Authorization 헤더가 올바르지 않습니다");

--- a/src/test/java/dooya/see/adapter/webapi/MemberApiTest.java
+++ b/src/test/java/dooya/see/adapter/webapi/MemberApiTest.java
@@ -25,7 +25,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.io.UnsupportedEncodingException;
 
 import static dooya.see.domain.member.MemberFixture.*;
-import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 
@@ -199,8 +198,8 @@ class MemberApiTest {
     }
 
     @Test
-    @DisplayName("")
-    void deactivated() throws JsonProcessingException, UnsupportedEncodingException {
+    @DisplayName("유효한 토큰으로 회원 탈퇴 요청 시 회원 상태가 DEACTIVATED로 변경되고 성공 응답을 반환한다")
+    void deactivateMyself() throws JsonProcessingException, UnsupportedEncodingException {
         memberRegister.register(createMemberRegisterRequest());
 
         MemberAuthRequest request = createMemberAuthRequest();
@@ -221,5 +220,39 @@ class MemberApiTest {
 
         Member member = memberRepository.findById(authResponse.memberId()).orElseThrow();
         assertThat(member.getStatus()).isEqualTo(MemberStatus.DEACTIVATED);
+    }
+
+    @Test
+    @DisplayName("Authorization 헤더 없이 회원 탈퇴 요청 시 401 Unauthorized 상태 코드를 반환한다")
+    void deactivateMyselfWithoutAuthorizationHeader() {
+        MvcTestResult result = mvcTester.patch().uri("/api/members/my/deactivate").exchange();
+
+        assertThat(result)
+                .apply(print())
+                .hasStatus(HttpStatus.UNAUTHORIZED);
+    }
+
+    @Test
+    @DisplayName("잘못된 형식의 Authorization 헤더로 회원 탈퇴 요청 시 401 Unauthorized 상태 코드를 반환한다")
+    void deactivateMyselfWithInvalidAuthorizationHeader() {
+        MvcTestResult result = mvcTester.patch().uri("/api/members/my/deactivate")
+                .header("Authorization", "InvalidTokenFormat")
+                .exchange();
+
+        assertThat(result)
+                .apply(print())
+                .hasStatus(HttpStatus.UNAUTHORIZED);
+    }
+    
+    @Test
+    @DisplayName("유효하지 않은 토큰으로 회원 탈퇴 요청 시 401 Unauthorized 상태 코드를 반환한다")
+    void deactivateMyselfWithInvalidToken() {
+        MvcTestResult result = mvcTester.patch().uri("/api/members/my/deactivate")
+                .header("Authorization", "Bearer invalidToken")
+                .exchange();
+
+        assertThat(result)
+                .apply(print())
+                .hasStatus(HttpStatus.UNAUTHORIZED);
     }
 }

--- a/src/test/java/dooya/see/adapter/webapi/MemberApiTest.java
+++ b/src/test/java/dooya/see/adapter/webapi/MemberApiTest.java
@@ -255,4 +255,26 @@ class MemberApiTest {
                 .apply(print())
                 .hasStatus(HttpStatus.UNAUTHORIZED);
     }
+
+    @Test
+    @DisplayName("")
+    void a() throws JsonProcessingException, UnsupportedEncodingException {
+        memberRegister.register(createMemberRegisterRequest());
+
+        MemberAuthRequest request = createMemberAuthRequest();
+        String requestJson = objectMapper.writeValueAsString(request);
+
+        MvcTestResult loginResult = mvcTester.post().uri("/api/members/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestJson).exchange();
+
+        MemberAuthResponse authResponse =
+                objectMapper.readValue(loginResult.getResponse().getContentAsString(), MemberAuthResponse.class);
+
+        MvcTestResult result = mvcTester.put().uri("/api/members/my/updateInfo")
+                .header("Authorization", "Bearer " + authResponse.accessToken())
+                .exchange();
+
+        assertThat(result).hasStatusOk();
+    }
 }

--- a/src/test/java/dooya/see/adapter/webapi/MemberApiTest.java
+++ b/src/test/java/dooya/see/adapter/webapi/MemberApiTest.java
@@ -25,6 +25,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.io.UnsupportedEncodingException;
 
 import static dooya.see.domain.member.MemberFixture.*;
+import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 
@@ -195,5 +196,27 @@ class MemberApiTest {
         assertThat(result)
                 .apply(print())
                 .hasStatus(HttpStatus.UNAUTHORIZED);
+    }
+
+    @Test
+    @DisplayName("")
+    void deactivated() throws JsonProcessingException, UnsupportedEncodingException {
+        memberRegister.register(createMemberRegisterRequest());
+
+        MemberAuthRequest request = createMemberAuthRequest();
+        String requestJson = objectMapper.writeValueAsString(request);
+
+        MvcTestResult loginResult = mvcTester.post().uri("/api/members/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestJson).exchange();
+
+        MemberAuthResponse authResponse =
+                objectMapper.readValue(loginResult.getResponse().getContentAsString(), MemberAuthResponse.class);
+
+        MvcTestResult getCurrentMemberResult = mvcTester.patch().uri("/api/members/my/deactivate")
+                .header("Authorization", "Bearer " + authResponse.accessToken())
+                .exchange();
+
+        assertThat(getCurrentMemberResult).hasStatusOk();
     }
 }

--- a/src/test/java/dooya/see/adapter/webapi/MemberApiTest.java
+++ b/src/test/java/dooya/see/adapter/webapi/MemberApiTest.java
@@ -213,10 +213,13 @@ class MemberApiTest {
         MemberAuthResponse authResponse =
                 objectMapper.readValue(loginResult.getResponse().getContentAsString(), MemberAuthResponse.class);
 
-        MvcTestResult getCurrentMemberResult = mvcTester.patch().uri("/api/members/my/deactivate")
+        MvcTestResult result = mvcTester.patch().uri("/api/members/my/deactivate")
                 .header("Authorization", "Bearer " + authResponse.accessToken())
                 .exchange();
 
-        assertThat(getCurrentMemberResult).hasStatusOk();
+        assertThat(result).hasStatusOk();
+
+        Member member = memberRepository.findById(authResponse.memberId()).orElseThrow();
+        assertThat(member.getStatus()).isEqualTo(MemberStatus.DEACTIVATED);
     }
 }

--- a/src/test/java/dooya/see/adapter/webapi/MemberApiTest.java
+++ b/src/test/java/dooya/see/adapter/webapi/MemberApiTest.java
@@ -22,7 +22,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.io.UnsupportedEncodingException;
 
 import static dooya.see.domain.member.MemberFixture.*;
-import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 
@@ -255,8 +254,8 @@ class MemberApiTest {
     }
 
     @Test
-    @DisplayName("")
-    void a() throws JsonProcessingException, UnsupportedEncodingException {
+    @DisplayName("유효한 토큰으로 회원 정보 수정 요청 시 회원 정보가 변경되고 성공 응답을 반환한다")
+    void updateMyInfo() throws JsonProcessingException, UnsupportedEncodingException {
         memberRegister.register(createMemberRegisterRequest());
 
         MemberAuthRequest request = createMemberAuthRequest();
@@ -284,5 +283,65 @@ class MemberApiTest {
         assertThat(member.getNickname()).isEqualTo(updateInfoRequest.nickname());
         assertThat(member.getDetail().getProfile().address()).isEqualTo(updateInfoRequest.profileAddress());
         assertThat(member.getDetail().getIntroduction()).isEqualTo(updateInfoRequest.introduction());
+    }
+
+    @Test
+    @DisplayName("본문 없이 회원 정보 수정 요청 시 400 Bad Request 상태 코드를 반환한다")
+    void updateMyInfoWithoutRequestBody() {
+        MvcTestResult result = mvcTester.put().uri("/api/members/my/updateInfo").exchange();
+
+        assertThat(result)
+                .apply(print())
+                .hasStatus(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    @DisplayName("Authorization 헤더 없이 회원 정보 수정 요청 시 401 Unauthorized 상태 코드를 반환한다")
+    void updateMyInfoWithoutAuthorizationHeader() throws JsonProcessingException {
+        MemberInfoUpdateRequest request = createMemberInfoUpdateRequest();
+        String requestJson = objectMapper.writeValueAsString(request);
+
+        MvcTestResult result = mvcTester.put().uri("/api/members/my/updateInfo")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestJson)
+                .exchange();
+
+        assertThat(result)
+                .apply(print())
+                .hasStatus(HttpStatus.UNAUTHORIZED);
+    }
+
+    @Test
+    @DisplayName("잘못된 형식의 Authorization 헤더로 회원 정보 수정 요청 시 401 Unauthorized 상태 코드를 반환한다")
+    void updateMyInfoWithInvalidAuthorizationHeader() throws JsonProcessingException {
+        MemberInfoUpdateRequest request = createMemberInfoUpdateRequest();
+        String requestJson = objectMapper.writeValueAsString(request);
+
+        MvcTestResult result = mvcTester.put().uri("/api/members/my/updateInfo")
+                .header("Authorization", "InvalidTokenFormat")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestJson)
+                .exchange();
+
+        assertThat(result)
+                .apply(print())
+                .hasStatus(HttpStatus.UNAUTHORIZED);
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 토큰으로 회원 정보 수정 요청 시 401 Unauthorized 상태 코드를 반환한다")
+    void updateMyInfoWithInvalidToken() throws JsonProcessingException {
+        MemberInfoUpdateRequest request = createMemberInfoUpdateRequest();
+        String requestJson = objectMapper.writeValueAsString(request);
+
+        MvcTestResult result = mvcTester.put().uri("/api/members/my/updateInfo")
+                .header("Authorization", "Bearer invalidToken")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestJson)
+                .exchange();
+
+        assertThat(result)
+                .apply(print())
+                .hasStatus(HttpStatus.UNAUTHORIZED);
     }
 }

--- a/src/test/java/dooya/see/adapter/webapi/MemberApiTest.java
+++ b/src/test/java/dooya/see/adapter/webapi/MemberApiTest.java
@@ -7,10 +7,7 @@ import dooya.see.adapter.webapi.dto.MemberProfileResponse;
 import dooya.see.adapter.webapi.dto.MemberRegisterResponse;
 import dooya.see.application.member.provided.MemberRegister;
 import dooya.see.application.member.required.MemberRepository;
-import dooya.see.domain.member.MemberAuthRequest;
-import dooya.see.domain.member.Member;
-import dooya.see.domain.member.MemberRegisterRequest;
-import dooya.see.domain.member.MemberStatus;
+import dooya.see.domain.member.*;
 import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -25,6 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.io.UnsupportedEncodingException;
 
 import static dooya.see.domain.member.MemberFixture.*;
+import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 
@@ -271,10 +269,20 @@ class MemberApiTest {
         MemberAuthResponse authResponse =
                 objectMapper.readValue(loginResult.getResponse().getContentAsString(), MemberAuthResponse.class);
 
+        MemberInfoUpdateRequest updateInfoRequest = createMemberInfoUpdateRequest();
+        String updateRequestJson = objectMapper.writeValueAsString(updateInfoRequest);
+
         MvcTestResult result = mvcTester.put().uri("/api/members/my/updateInfo")
                 .header("Authorization", "Bearer " + authResponse.accessToken())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(updateRequestJson)
                 .exchange();
 
         assertThat(result).hasStatusOk();
+
+        Member member = memberRepository.findById(authResponse.memberId()).orElseThrow();
+        assertThat(member.getNickname()).isEqualTo(updateInfoRequest.nickname());
+        assertThat(member.getDetail().getProfile().address()).isEqualTo(updateInfoRequest.profileAddress());
+        assertThat(member.getDetail().getIntroduction()).isEqualTo(updateInfoRequest.introduction());
     }
 }

--- a/src/test/java/dooya/see/domain/member/MemberFixture.java
+++ b/src/test/java/dooya/see/domain/member/MemberFixture.java
@@ -9,6 +9,10 @@ public class MemberFixture {
         return createMemberRegisterRequest("dooya@see.com");
     }
 
+    public static MemberInfoUpdateRequest createMemberInfoUpdateRequest() {
+        return new MemberInfoUpdateRequest("dooyaya", "niceaddress", "자기소개");
+    }
+
     public static PasswordEncoder createPasswordEncoder() {
         return new PasswordEncoder() {
             @Override


### PR DESCRIPTION
## 📌 Issue

<!-- 해결하려는 이슈 번호나 주제를 명확하게 적어주세요. -->

- closed #104 

---

## 🧐 현재 상황

<!-- 현재 발생한 문제, 개선이 필요한 사항을 간략히 설명해주세요. -->

- Member Primary Adapter 기능 추가 (탈퇴, 정보수정)

---

## 🎯 목표

<!-- 이슈를 통해 달성하고자 하는 목표를 설명해주세요. -->

- Member Primary Adapter 기능 추가 (탈퇴, 정보수정)

---

## 🛠 작업 내용

- 작업 할 내용을 입력해주세요.

- [x] Member Primary Adapter 기능 추가 (탈퇴, 정보수정)
- [x] 테스트 작성

---

## 🚀 기타 사항

<!-- 리뷰어가 추가적으로 알아야 할 사항이 있다면 기재해주세요. -->

- 추가적인 내용을 작성해주세요.(참고 자료, 협업 내용)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 내 계정 비활성화 기능 추가: 로그인한 사용자가 자신의 계정을 비활성화할 수 있습니다.
  - 내 정보 수정 기능 추가: 닉네임, 프로필 주소, 자기소개 등 프로필 정보를 갱신할 수 있습니다.
- Tests
  - 비활성화 및 정보 수정 플로우에 대한 성공/오류 케이스 테스트를 추가해 인증 헤더 및 유효성 검증 시나리오를 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->