### PR TITLE
ArchUnit을 활용한 헥사고날 아키텍처 테스트 구현

### DIFF
--- a/src/test/java/dooya/see/HexagonalArchitectureTest.java
+++ b/src/test/java/dooya/see/HexagonalArchitectureTest.java
@@ -172,8 +172,7 @@ public class HexagonalArchitectureTest {
         void b() {
             classes()
                     .that().resideInAPackage("..application..")
-                    .and().areNotInterfaces()
-                    .and().haveSimpleNameContaining("Service")
+                    .and().areAnnotatedWith("org.springframework.stereotype.Service")
                     .should().haveSimpleNameEndingWith("Service")
                     .because("애플리케이션 서비스는 명확한 명명 규칙을 따라야 합니다")
                     .check(classes);

--- a/src/test/java/dooya/see/HexagonalArchitectureTest.java
+++ b/src/test/java/dooya/see/HexagonalArchitectureTest.java
@@ -1,0 +1,17 @@
+package dooya.see;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.core.importer.ImportOption;
+import org.junit.jupiter.api.BeforeEach;
+
+public class HexagonalArchitectureTest {
+    private JavaClasses classes;
+
+    @BeforeEach
+    void setUp() {
+        classes = new ClassFileImporter()
+                .withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_TESTS)
+                .importPackages("dooya.see");
+    }
+}

--- a/src/test/java/dooya/see/HexagonalArchitectureTest.java
+++ b/src/test/java/dooya/see/HexagonalArchitectureTest.java
@@ -24,7 +24,6 @@ public class HexagonalArchitectureTest {
     @Nested
     @DisplayName("계층형 아키텍처 검증")
     class LayeredArchitectureTest {
-
         @Test
         @DisplayName("헥사고날 아키텍처 계층 의존성 규칙을 준수한다")
         void a() {
@@ -58,6 +57,23 @@ public class HexagonalArchitectureTest {
                     .that().resideInAPackage("..application..")
                     .should().dependOnClassesThat()
                     .resideInAPackage("..adapter..")
+                    .check(classes);
+        }
+    }
+
+    @Nested
+    @DisplayName("도메인 비즈니스 로직")
+    class DomainBusinessLogicTest {
+        @Test
+        @DisplayName("도메인은 Spring 컨테이너 애노테이션을 사용하면 안된다")
+        void d() {
+            noClasses()
+                    .that().resideInAPackage("..domain..")
+                    .should().beAnnotatedWith("org.springframework.stereotype.Component")
+                    .orShould().beAnnotatedWith("org.springframework.stereotype.Service")
+                    .orShould().beAnnotatedWith("org.springframework.stereotype.Repository")
+                    .orShould().beAnnotatedWith("org.springframework.context.annotation.Configuration")
+                    .because("도메인은 Spring 컨테이너에 의존하지 않고 순수한 비즈니스 로직에 집중해야 합니다")
                     .check(classes);
         }
     }

--- a/src/test/java/dooya/see/HexagonalArchitectureTest.java
+++ b/src/test/java/dooya/see/HexagonalArchitectureTest.java
@@ -9,6 +9,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+
 public class HexagonalArchitectureTest {
     private JavaClasses classes;
 
@@ -36,6 +38,16 @@ public class HexagonalArchitectureTest {
                     .whereLayer("Application").mayOnlyBeAccessedByLayers("Adapter")
                     .whereLayer("Adapter").mayNotBeAccessedByAnyLayer()
 
+                    .check(classes);
+        }
+
+        @Test
+        @DisplayName("도메인 계층은 외부 의존성이 없어야 한다")
+        void b() {
+            noClasses()
+                    .that().resideInAPackage("..domain..")
+                    .should().dependOnClassesThat()
+                    .resideInAnyPackage("..application..", "..adapter..")
                     .check(classes);
         }
     }

--- a/src/test/java/dooya/see/HexagonalArchitectureTest.java
+++ b/src/test/java/dooya/see/HexagonalArchitectureTest.java
@@ -76,5 +76,16 @@ public class HexagonalArchitectureTest {
                     .because("도메인은 Spring 컨테이너에 의존하지 않고 순수한 비즈니스 로직에 집중해야 합니다")
                     .check(classes);
         }
+
+        @Test
+        @DisplayName("도메인은 웹 관련 애노테이션을 사용하면 안된다")
+        void e() {
+            noClasses()
+                    .that().resideInAPackage("..domain..")
+                    .should().dependOnClassesThat()
+                    .resideInAnyPackage("org.springframework.web..", "jakarta.servlet..")
+                    .because("도메인은 웹 계층과 독립적이어야 합니다")
+                    .check(classes);
+        }
     }
 }

--- a/src/test/java/dooya/see/HexagonalArchitectureTest.java
+++ b/src/test/java/dooya/see/HexagonalArchitectureTest.java
@@ -195,5 +195,15 @@ public class HexagonalArchitectureTest {
                     .because("도메인 계층은 Spring 애노테이션을 사용하지 않아야 합니다")
                     .check(classes);
         }
+        
+        @Test
+        @DisplayName("@Transactional은 애플리케이션 서비스에서만 사용한다")
+        void b() {
+            classes()
+                    .that().areAnnotatedWith("org.springframework.transaction.annotation.Transactional")
+                    .should().resideInAPackage("..application..")
+                    .because("트랜잭션 경계는 애플리케이션 서비스에서 관리해야 합니다")
+                    .check(classes);
+        }
     }
 }

--- a/src/test/java/dooya/see/HexagonalArchitectureTest.java
+++ b/src/test/java/dooya/see/HexagonalArchitectureTest.java
@@ -179,4 +179,21 @@ public class HexagonalArchitectureTest {
                     .check(classes);
         }
     }
+
+    @Nested
+    @DisplayName("Spring 애노테이션 사용 규칙")
+    class SpringAnnotationTest {
+        @Test
+        @DisplayName("@Component 계열 애노테이션은 어댑터와 애플리케이션 서비스에서 사용된다")
+        void a() {
+            noClasses()
+                    .that().resideInAPackage("..domain..")
+                    .should().beAnnotatedWith("org.springframework.stereotype.Component")
+                    .orShould().beAnnotatedWith("org.springframework.stereotype.Service")
+                    .orShould().beAnnotatedWith("org.springframework.stereotype.Repository")
+                    .orShould().beAnnotatedWith("org.springframework.web.bind.annotation.RestController")
+                    .because("도메인 계층은 Spring 애노테이션을 사용하지 않아야 합니다")
+                    .check(classes);
+        }
+    }
 }

--- a/src/test/java/dooya/see/HexagonalArchitectureTest.java
+++ b/src/test/java/dooya/see/HexagonalArchitectureTest.java
@@ -3,7 +3,11 @@ package dooya.see;
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
 import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.library.Architectures;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 
 public class HexagonalArchitectureTest {
     private JavaClasses classes;
@@ -13,5 +17,26 @@ public class HexagonalArchitectureTest {
         classes = new ClassFileImporter()
                 .withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_TESTS)
                 .importPackages("dooya.see");
+    }
+
+    @Nested
+    @DisplayName("계층형 아키텍처 검증")
+    class LayeredArchitectureTest {
+
+        @Test
+        @DisplayName("헥사고날 아키텍처 계층 의존성 규칙 검증")
+        void a() {
+            Architectures.layeredArchitecture()
+                    .consideringOnlyDependenciesInLayers()
+                    .layer("Domain").definedBy("..domain..")
+                    .layer("Application").definedBy("..application..")
+                    .layer("Adapter").definedBy("..adapter..")
+
+                    .whereLayer("Domain").mayOnlyBeAccessedByLayers("Application", "Adapter")
+                    .whereLayer("Application").mayOnlyBeAccessedByLayers("Adapter")
+                    .whereLayer("Adapter").mayNotBeAccessedByAnyLayer()
+
+                    .check(classes);
+        }
     }
 }

--- a/src/test/java/dooya/see/HexagonalArchitectureTest.java
+++ b/src/test/java/dooya/see/HexagonalArchitectureTest.java
@@ -3,12 +3,14 @@ package dooya.see;
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
 import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
 import com.tngtech.archunit.library.Architectures;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
 
 public class HexagonalArchitectureTest {
@@ -93,6 +95,21 @@ public class HexagonalArchitectureTest {
         void f() {
             // JPA 애노테이션이 도메인 로직에 미치는 영향을 최소화하면서, 매핑을 위한 애노테이션 사용은 허용
             // 이 테스트는 문서화 목적으로 JPA 사용이 허용됨을 명시
+        }
+    }
+
+    @Nested
+    @DisplayName("포트와 어댑터 패턴")
+    class PortAndAdapterTest {
+        @Test
+        @DisplayName("Primary Port는 application.provided 패키지에 위치한다")
+        void a() {
+            classes()
+                    .that().areInterfaces()
+                    .and().resideInAPackage("..application..provided..")
+                    .should().bePublic()
+                    .because("Primary Port는 외부에서 애플리케이션을 호출하는 인터페이스입니다")
+                    .check(classes);
         }
     }
 }

--- a/src/test/java/dooya/see/HexagonalArchitectureTest.java
+++ b/src/test/java/dooya/see/HexagonalArchitectureTest.java
@@ -111,5 +111,16 @@ public class HexagonalArchitectureTest {
                     .because("Primary Port는 외부에서 애플리케이션을 호출하는 인터페이스입니다")
                     .check(classes);
         }
+
+        @Test
+        @DisplayName("Secondary Post는 application.required 패키지에 위치한다")
+        void b() {
+            classes()
+                    .that().areInterfaces()
+                    .and().resideInAnyPackage("..application..required..")
+                    .should().bePublic()
+                    .because("Secondary Port는 애플리케이션이 외부를 호출하는 인터페이스입니다")
+                    .check(classes);
+        }
     }
 }

--- a/src/test/java/dooya/see/HexagonalArchitectureTest.java
+++ b/src/test/java/dooya/see/HexagonalArchitectureTest.java
@@ -52,7 +52,7 @@ public class HexagonalArchitectureTest {
                     .resideInAnyPackage("..application..", "..adapter..")
                     .check(classes);
         }
-        
+
         @Test
         @DisplayName("애플리케이션 계층은 어댑터에 의존하면 안된다")
         void c() {
@@ -127,13 +127,13 @@ public class HexagonalArchitectureTest {
         @Test
         @DisplayName("어댑터는 포트 인터페이스를 구현해야 한다")
         void c() {
-            // 이 테스트는 실제로는 복잡한 검증이 필요하므로 
+            // 이 테스트는 실제로는 복잡한 검증이 필요하므로
             // 문서화 목적으로 어댑터가 포트 인터페이스를 구현해야 함을 명시
             // 실제 구현체들은 개별적으로 확인하는 것이 더 실용적임
-            
+
             // 예시: 웹 어댑터는 Primary Port를 주입받아 사용
             // 예시: 리포지토리 어댑터는 Secondary Port를 구현
-            
+
             // 향후 구체적인 어댑터 구현 시 개별 테스트 추가 예정
         }
     }
@@ -164,6 +164,18 @@ public class HexagonalArchitectureTest {
                     .and().haveSimpleNameEndingWith("Repository")
                     .should().haveSimpleNameEndingWith("Repository")
                     .because("리포지토리는 명확한 명명 규칙을 따라야 합니다")
+                    .check(classes);
+        }
+
+        @Test
+        @DisplayName("애플리케이션 서비스는 Service로 끝나야 한다")
+        void b() {
+            classes()
+                    .that().resideInAPackage("..application..")
+                    .and().areNotInterfaces()
+                    .and().haveSimpleNameContaining("Service")
+                    .should().haveSimpleNameEndingWith("Service")
+                    .because("애플리케이션 서비스는 명확한 명명 규칙을 따라야 합니다")
                     .check(classes);
         }
     }

--- a/src/test/java/dooya/see/HexagonalArchitectureTest.java
+++ b/src/test/java/dooya/see/HexagonalArchitectureTest.java
@@ -200,6 +200,7 @@ public class HexagonalArchitectureTest {
         void b() {
             classes()
                     .that().areAnnotatedWith("org.springframework.transaction.annotation.Transactional")
+                    .or().areAnnotatedWith("jakarta.transaction.Transactional")
                     .should().resideInAPackage("..application..")
                     .because("트랜잭션 경계는 애플리케이션 서비스에서 관리해야 합니다")
                     .check(classes);

--- a/src/test/java/dooya/see/HexagonalArchitectureTest.java
+++ b/src/test/java/dooya/see/HexagonalArchitectureTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+import static com.tngtech.archunit.library.dependencies.SlicesRuleDefinition.slices;
 
 public class HexagonalArchitectureTest {
     private JavaClasses classes;
@@ -134,6 +135,20 @@ public class HexagonalArchitectureTest {
             // 예시: 리포지토리 어댑터는 Secondary Port를 구현
             
             // 향후 구체적인 어댑터 구현 시 개별 테스트 추가 예정
+        }
+    }
+
+    @Nested
+    @DisplayName("애그리거트와 경계")
+    class AggregateAndBoundaryTest {
+        @Test
+        @DisplayName("애그리거트 내부 패키지는 순환 의존성이 없어야 한다")
+        void a() {
+            slices()
+                    .matching("..domain.(*)..")
+                    .should().beFreeOfCycles()
+                    .because("애그리거트 간에는 순환 의존성이 없어야 합니다")
+                    .check(classes);
         }
     }
 }

--- a/src/test/java/dooya/see/HexagonalArchitectureTest.java
+++ b/src/test/java/dooya/see/HexagonalArchitectureTest.java
@@ -26,7 +26,7 @@ public class HexagonalArchitectureTest {
     class LayeredArchitectureTest {
 
         @Test
-        @DisplayName("헥사고날 아키텍처 계층 의존성 규칙 검증")
+        @DisplayName("헥사고날 아키텍처 계층 의존성 규칙을 준수한다")
         void a() {
             Architectures.layeredArchitecture()
                     .consideringOnlyDependenciesInLayers()
@@ -48,6 +48,16 @@ public class HexagonalArchitectureTest {
                     .that().resideInAPackage("..domain..")
                     .should().dependOnClassesThat()
                     .resideInAnyPackage("..application..", "..adapter..")
+                    .check(classes);
+        }
+        
+        @Test
+        @DisplayName("애플리케이션 계층은 어댑터에 의존하면 안된다")
+        void c() {
+            noClasses()
+                    .that().resideInAPackage("..application..")
+                    .should().dependOnClassesThat()
+                    .resideInAPackage("..adapter..")
                     .check(classes);
         }
     }

--- a/src/test/java/dooya/see/HexagonalArchitectureTest.java
+++ b/src/test/java/dooya/see/HexagonalArchitectureTest.java
@@ -87,5 +87,12 @@ public class HexagonalArchitectureTest {
                     .because("도메인은 웹 계층과 독립적이어야 합니다")
                     .check(classes);
         }
+
+        @Test
+        @DisplayName("도메인은 JPA/Hibernate를 사용할 수 있다")
+        void f() {
+            // JPA 애노테이션이 도메인 로직에 미치는 영향을 최소화하면서, 매핑을 위한 애노테이션 사용은 허용
+            // 이 테스트는 문서화 목적으로 JPA 사용이 허용됨을 명시
+        }
     }
 }

--- a/src/test/java/dooya/see/HexagonalArchitectureTest.java
+++ b/src/test/java/dooya/see/HexagonalArchitectureTest.java
@@ -161,8 +161,8 @@ public class HexagonalArchitectureTest {
             classes()
                     .that().areInterfaces()
                     .and().resideInAPackage("..application..required..")
-                    .and().haveSimpleNameEndingWith("Repository")
                     .should().haveSimpleNameEndingWith("Repository")
+                    .orShould().haveSimpleNameEndingWith("Manager")
                     .because("리포지토리는 명확한 명명 규칙을 따라야 합니다")
                     .check(classes);
         }

--- a/src/test/java/dooya/see/HexagonalArchitectureTest.java
+++ b/src/test/java/dooya/see/HexagonalArchitectureTest.java
@@ -113,14 +113,27 @@ public class HexagonalArchitectureTest {
         }
 
         @Test
-        @DisplayName("Secondary Post는 application.required 패키지에 위치한다")
+        @DisplayName("Secondary Port는 application.required 패키지에 위치한다")
         void b() {
             classes()
                     .that().areInterfaces()
-                    .and().resideInAnyPackage("..application..required..")
+                    .and().resideInAPackage("..application..required..")
                     .should().bePublic()
                     .because("Secondary Port는 애플리케이션이 외부를 호출하는 인터페이스입니다")
                     .check(classes);
+        }
+
+        @Test
+        @DisplayName("어댑터는 포트 인터페이스를 구현해야 한다")
+        void c() {
+            // 이 테스트는 실제로는 복잡한 검증이 필요하므로 
+            // 문서화 목적으로 어댑터가 포트 인터페이스를 구현해야 함을 명시
+            // 실제 구현체들은 개별적으로 확인하는 것이 더 실용적임
+            
+            // 예시: 웹 어댑터는 Primary Port를 주입받아 사용
+            // 예시: 리포지토리 어댑터는 Secondary Port를 구현
+            
+            // 향후 구체적인 어댑터 구현 시 개별 테스트 추가 예정
         }
     }
 }

--- a/src/test/java/dooya/see/HexagonalArchitectureTest.java
+++ b/src/test/java/dooya/see/HexagonalArchitectureTest.java
@@ -151,4 +151,20 @@ public class HexagonalArchitectureTest {
                     .check(classes);
         }
     }
+
+    @Nested
+    @DisplayName("명명 규칙")
+    class NamingConventionTest {
+        @Test
+        @DisplayName("리포지토리 인터페이스는 Repository로 끝나야 한다")
+        void a() {
+            classes()
+                    .that().areInterfaces()
+                    .and().resideInAPackage("..application..required..")
+                    .and().haveSimpleNameEndingWith("Repository")
+                    .should().haveSimpleNameEndingWith("Repository")
+                    .because("리포지토리는 명확한 명명 규칙을 따라야 합니다")
+                    .check(classes);
+        }
+    }
 }


### PR DESCRIPTION
## 📌 Issue

<!-- 해결하려는 이슈 번호나 주제를 명확하게 적어주세요. -->

- closed #112 

---

## 🧐 현재 상황

<!-- 현재 발생한 문제, 개선이 필요한 사항을 간략히 설명해주세요. -->

- 아키텍처를 잘 지키고 의존성이 올바르게 흘러가고 있는지에 대한 명확한 검증 테스트가 없음

---

## 🎯 목표

<!-- 이슈를 통해 달성하고자 하는 목표를 설명해주세요. -->

- ArchUnit을 활용한 헥사고날 아키텍처 테스트 구현

---

## 🛠 작업 내용

- 작업 할 내용을 입력해주세요.

- [x] ArchUnit을 활용한 헥사고날 아키텍처 테스트 구현

---

## 🚀 기타 사항

<!-- 리뷰어가 추가적으로 알아야 할 사항이 있다면 기재해주세요. -->

- 추가적인 내용을 작성해주세요.(참고 자료, 협업 내용)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * 헥사고날 아키텍처 준수를 자동 점검하는 테스트 스위트를 추가했습니다. 도메인·애플리케이션·어댑터의 계층별 접근·의존성 제약, 포트(제공/요구) 공개 규칙, 어댑터 경계, 도메인 슬라이스의 순환 의존성 금지, 리포지토리·서비스 명명 규칙, 스프링 애노테이션 및 @Transactional 사용 범위를 JUnit 5/ArchUnit 기반으로 검증합니다. 일부 어댑터 관련 검증은 추후 보강 예정입니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->