### PR TITLE
테스트 커버리지 측정을 위한 JaCoCo 설정 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -83,8 +83,14 @@ tasks.jacocoTestCoverageVerification {
     violationRules {
         rule {
             limit {
+                counter = "LINE"
+                value = "COVEREDRATIO"
                 minimum = "0.80".toBigDecimal()
             }
         }
     }
+}
+
+tasks.check {
+    dependsOn(tasks.jacocoTestCoverageVerification, tasks.jacocoTestReport)
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     id("org.springframework.boot") version "3.5.4"
     id("io.spring.dependency-management") version "1.1.7"
     id("com.github.spotbugs") version "6.1.11"
+    jacoco
 }
 
 group = "dooya"
@@ -59,4 +60,31 @@ tasks.named<Test>("test") {
 
 spotbugs {
     excludeFilter.set(file("${projectDir}/spotbugs-exclude-filter.xml"))
+}
+
+jacoco {
+    toolVersion = "0.8.12"
+}
+
+tasks.test {
+    finalizedBy(tasks.jacocoTestReport)
+}
+
+tasks.jacocoTestReport {
+    dependsOn(tasks.test)
+    reports {
+        xml.required.set(false)
+        csv.required.set(false)
+        html.outputLocation.set(layout.buildDirectory.dir("jacocoHtml"))
+    }
+}
+
+tasks.jacocoTestCoverageVerification {
+    violationRules {
+        rule {
+            limit {
+                minimum = "0.80".toBigDecimal()
+            }
+        }
+    }
 }


### PR DESCRIPTION
## 📌 Issue

<!-- 해결하려는 이슈 번호나 주제를 명확하게 적어주세요. -->

- closed #127 

---

## 🧐 현재 상황

<!-- 현재 발생한 문제, 개선이 필요한 사항을 간략히 설명해주세요. -->

- 테스트 커버리지 측정을 위한 JaCoCo 설정 추가

---

## 🎯 목표

<!-- 이슈를 통해 달성하고자 하는 목표를 설명해주세요. -->

- 테스트 커버리지 측정을 위한 JaCoCo 설정 추가

---

## 🛠 작업 내용

- 테스트 커버리지 측정을 위한 JaCoCo 설정 추가

- [x] 테스트 커버리지 측정을 위한 JaCoCo 설정 추가

---

## 🚀 기타 사항

<!-- 리뷰어가 추가적으로 알아야 할 사항이 있다면 기재해주세요. -->

- 추가적인 내용을 작성해주세요.(참고 자료, 협업 내용)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 신규 기능
  - 사용자 기능 변경 없음.
* 작업(Chores)
  - 빌드에 코드 커버리지 도구 통합.
  - 테스트 완료 후 자동으로 커버리지 리포트 생성되도록 구성.
  - XML/CSV 리포트 비활성화, HTML 리포트만 생성 및 출력 위치 지정.
  - 빌드 검증 단계에 커버리지 검사 추가 및 최소 80% 기준 적용(미달 시 빌드 실패).
* 테스트
  - 커버리지 리포트와 검증을 CI/테스트 파이프라인에 연동.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->