### PR TITLE
도메인 이벤트 처리를 TransactionalEventListener로 변경

### DIFF
--- a/src/main/java/dooya/see/application/post/PostStatsEventHandler.java
+++ b/src/main/java/dooya/see/application/post/PostStatsEventHandler.java
@@ -1,82 +1,90 @@
 package dooya.see.application.post;
 
-import dooya.see.application.post.required.PostStatsRepository;
-import dooya.see.domain.post.PostStats;
+import dooya.see.application.post.provided.PostStatsManager;
 import dooya.see.domain.post.event.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
 @Slf4j
 @Component
-@Transactional
 @RequiredArgsConstructor
 public class PostStatsEventHandler {
-    private final PostStatsRepository postStatsRepository;
+    private final PostStatsManager postStatsManager;
 
-    @EventListener
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handlePostCreated(PostCreated event) {
         log.info("PostCreated 이벤트 처리: postId={}, memberId={}", event.postId(), event.memberId());
-        PostStats stats = PostStats.create(event.postId());
-        postStatsRepository.save(stats);
+
+        try {
+            postStatsManager.initializePostStats(event.postId());
+        } catch (Exception e) {
+            log.error("게시물 통계 초기화 실패: postId={}", event.postId(), e);
+        }
     }
 
-    @EventListener
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handlePostViewed(PostViewed event) {
-        if (event.postId() != null) {
-            log.info("PostViewed 이벤트 처리: postId={}, viewerId={}", event.postId(), event.memberId());
-            postStatsRepository.findByPostId(event.postId())
-                .ifPresent(PostStats::incrementViewCount);
+        if (event.postId() == null) return;
+
+        log.info("PostViewed 이벤트 처리: postId={}, viewerId={}", event.postId(), event.memberId());
+
+        try {
+            postStatsManager.incrementViewCount(event.postId());
+        } catch (Exception e) {
+            log.error("조회수 증가 실패: postId={}", event.postId(), e);
         }
     }
 
-    @EventListener
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handlePostLiked(PostLiked event) {
-        if (event.postId() != null) {
-            log.info("PostLiked 이벤트 처리: postId={}, memberId={}", event.postId(), event.memberId());
-            postStatsRepository.findByPostId(event.postId())
-                .ifPresent(PostStats::incrementLikeCount);
+        if (event.postId() == null) return;
+
+        log.info("PostLiked 이벤트 처리: postId={}, memberId={}", event.postId(), event.memberId());
+
+        try {
+            postStatsManager.incrementLikeCount(event.postId());
+        } catch (Exception e) {
+            log.error("좋아요 수 증가 실패: postId={}", event.postId(), e);
         }
     }
 
-    @EventListener
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handlePostUnliked(PostUnliked event) {
-        if (event.postId() != null) {
-            log.info("PostUnliked 이벤트 처리: postId={}, memberId={}", event.postId(), event.memberId());
-            postStatsRepository.findByPostId(event.postId())
-                .ifPresent(PostStats::decrementLikeCount);
+        if (event.postId() == null) return;
+
+        log.info("PostUnliked 이벤트 처리: postId={}, memberId={}", event.postId(), event.memberId());
+
+        try {
+            postStatsManager.decrementLikeCount(event.postId());
+        } catch (Exception e) {
+            log.error("좋아요 수 감소 실패: postId={}", event.postId(), e);
         }
     }
 
-    @EventListener
+    // 다른 이벤트들은 로깅만 수행
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handlePostUpdated(PostUpdated event) {
         log.info("PostUpdated 이벤트 처리: postId={}, memberId={}, titleChanged={}, bodyChanged={}, categoryChanged={}",
-            event.postId(), event.memberId(), event.titleChanged(), event.bodyChanged(), event.categoryChanged());
-        // 게시글 수정 시 특별한 통계 처리는 없지만 로그는 남김
+                event.postId(), event.memberId(), event.titleChanged(), event.bodyChanged(), event.categoryChanged());
     }
 
-    @EventListener
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handlePostPublished(PostPublished event) {
         log.info("PostPublished 이벤트 처리: postId={}, memberId={}", event.postId(), event.memberId());
-        // 게시글 발행 시 특별한 통계 처리는 없지만 로그는 남김
     }
 
-    @EventListener
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handlePostHidden(PostHidden event) {
         log.info("PostHidden 이벤트 처리: postId={}, memberId={}, previousStatus={}",
-            event.postId(), event.memberId(), event.previousStatus());
-        // 게시글 숨김 시 특별한 통계 처리는 없지만 로그는 남김
+                event.postId(), event.memberId(), event.previousStatus());
     }
 
-    @EventListener
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handlePostDeleted(PostDeleted event) {
         log.info("PostDeleted 이벤트 처리: postId={}, memberId={}, previousStatus={}",
-            event.postId(), event.memberId(), event.previousStatus());
-        // 게시글 삭제 시 통계 데이터도 삭제할 수 있지만, 지금은 로그만 남김
-        // 실제로는 비즈니스 요구사항에 따라 통계 데이터 보존/삭제 결정
+                event.postId(), event.memberId(), event.previousStatus());
     }
 }

--- a/src/main/java/dooya/see/application/post/PostStatsEventHandler.java
+++ b/src/main/java/dooya/see/application/post/PostStatsEventHandler.java
@@ -4,6 +4,7 @@ import dooya.see.application.post.provided.PostStatsManager;
 import dooya.see.domain.post.event.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -14,6 +15,7 @@ import org.springframework.transaction.event.TransactionalEventListener;
 public class PostStatsEventHandler {
     private final PostStatsManager postStatsManager;
 
+    @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handlePostCreated(PostCreated event) {
         log.info("PostCreated 이벤트 처리: postId={}, memberId={}", event.postId(), event.memberId());
@@ -25,6 +27,7 @@ public class PostStatsEventHandler {
         }
     }
 
+    @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handlePostViewed(PostViewed event) {
         if (event.postId() == null) return;
@@ -38,6 +41,7 @@ public class PostStatsEventHandler {
         }
     }
 
+    @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handlePostLiked(PostLiked event) {
         if (event.postId() == null) return;
@@ -51,6 +55,7 @@ public class PostStatsEventHandler {
         }
     }
 
+    @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handlePostUnliked(PostUnliked event) {
         if (event.postId() == null) return;
@@ -65,23 +70,27 @@ public class PostStatsEventHandler {
     }
 
     // 다른 이벤트들은 로깅만 수행
+    @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handlePostUpdated(PostUpdated event) {
         log.info("PostUpdated 이벤트 처리: postId={}, memberId={}, titleChanged={}, bodyChanged={}, categoryChanged={}",
                 event.postId(), event.memberId(), event.titleChanged(), event.bodyChanged(), event.categoryChanged());
     }
 
+    @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handlePostPublished(PostPublished event) {
         log.info("PostPublished 이벤트 처리: postId={}, memberId={}", event.postId(), event.memberId());
     }
 
+    @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handlePostHidden(PostHidden event) {
         log.info("PostHidden 이벤트 처리: postId={}, memberId={}, previousStatus={}",
                 event.postId(), event.memberId(), event.previousStatus());
     }
 
+    @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handlePostDeleted(PostDeleted event) {
         log.info("PostDeleted 이벤트 처리: postId={}, memberId={}, previousStatus={}",

--- a/src/main/java/dooya/see/application/post/PostStatsService.java
+++ b/src/main/java/dooya/see/application/post/PostStatsService.java
@@ -1,0 +1,143 @@
+package dooya.see.application.post;
+
+import dooya.see.application.post.provided.PostStatsManager;
+import dooya.see.application.post.required.PostStatsRepository;
+import dooya.see.domain.post.PostStats;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class PostStatsService implements PostStatsManager {
+    private final PostStatsRepository postStatsRepository;
+
+    @Override
+    public void initializePostStats(Long postId) {
+        log.debug("게시물 통계 초기화: postId={}", postId);
+
+        if (preventDuplicateStatsCreation(postId))
+            return;
+
+        PostStats stats = createNewStats(postId);
+        saveStats(stats);
+
+        log.info("게시물 통계 초기화 완료: postId={}", postId);
+    }
+
+    @Override
+    public void incrementViewCount(Long postId) {
+        log.debug("조회수 증가 처리: postId={}", postId);
+        executeStatsOperation(postId, "조회수 증가", PostStats::incrementViewCount);
+    }
+
+    @Override
+    public void incrementLikeCount(Long postId) {
+        log.debug("좋아요 수 증가 처리: postId={}", postId);
+        executeStatsOperation(postId, "좋아요 증가", PostStats::incrementLikeCount);
+    }
+
+    @Override
+    public void decrementLikeCount(Long postId) {
+        log.debug("좋아요 수 감소 처리: postId={}", postId);
+        executeStatsOperation(postId, "좋아요 감소", PostStats::decrementLikeCount);
+    }
+
+    @Override
+    public void incrementCommentCount(Long postId) {
+        log.debug("댓글 수 증가 처리: postId={}", postId);
+        executeStatsOperation(postId, "댓글 수 증가", PostStats::incrementCommentCount);
+    }
+
+    @Override
+    public void decrementCommentCount(Long postId) {
+        log.debug("댓글 수 감소 처리: postId={}", postId);
+        executeStatsOperation(postId, "댓글 수 감소", PostStats::decrementCommentCount);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<PostStats> getPostStats(Long postId) {
+        log.debug("게시물 통계 조회: postId={}", postId);
+        return findStatsByPostId(postId);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public PostStats getPostStatsOrThrow(Long postId) {
+        log.debug("게시물 통계 조회(필수): postId={}", postId);
+        return findStatsByPostId(postId)
+                .orElseThrow(() -> createStatsNotFoundException(postId));
+    }
+
+    // Stats Creation 관련 메서드
+    private static PostStats createNewStats(Long postId) {
+        return PostStats.create(postId);
+    }
+
+    private PostStats saveStats(PostStats stats) {
+        return postStatsRepository.save(stats);
+    }
+
+    // Stats Operation 관련 메서드
+    private void executeStatsOperation(Long postId, String operation, StatsOperation statsOperation) {
+        Optional<PostStats> statsOptional = findStatsByPostId(postId);
+
+        if (statsOptional.isPresent()) {
+            PostStats stats = statsOptional.get();
+            statsOperation.execute(stats);
+            saveStats(stats);
+            logOperationSuccess(operation, postId);
+        } else {
+            logOperationIgnored(operation, postId);
+        }
+    }
+
+    // Stats 조회 관련 메서드
+    private Optional<PostStats> findStatsByPostId(Long postId) {
+        return postStatsRepository.findByPostId(postId);
+    }
+
+    // 중복 방지 관련 메서드
+    private boolean preventDuplicateStatsCreation(Long postId) {
+        if (isStatsAlreadyExists(postId)) {
+            logDuplicateStatsWarning(postId);
+            return true;
+        }
+        return false;
+    }
+
+    // 검증 관련 메서드
+    private boolean isStatsAlreadyExists(Long postId) {
+        return postStatsRepository.findByPostId(postId).isPresent();
+    }
+
+    // 예외 생성 관련 메서드
+    private static IllegalArgumentException createStatsNotFoundException(Long postId) {
+        return new IllegalArgumentException("PostStats not found for postId: " + postId);
+    }
+
+    // 로깅 관련 메서드
+    private void logOperationSuccess(String operation, Long postId) {
+        log.info("{} 완료: postId={}", operation, postId);
+    }
+
+    private void logOperationIgnored(String operation, Long postId) {
+        log.warn("PostStats not found for postId: {}, {} 작업 무시", postId, operation);
+    }
+
+    private void logDuplicateStatsWarning(Long postId) {
+        log.warn("PostStats already exists for postId: {}", postId);
+    }
+
+    // Functional Interface 정의
+    @FunctionalInterface
+    private interface StatsOperation {
+        void execute(PostStats stats);
+    }
+}

--- a/src/main/java/dooya/see/application/post/provided/PostStatsManager.java
+++ b/src/main/java/dooya/see/application/post/provided/PostStatsManager.java
@@ -1,0 +1,26 @@
+package dooya.see.application.post.provided;
+
+import dooya.see.domain.post.PostStats;
+
+import java.util.Optional;
+
+/**
+ * 게시물 통계 관리를 위한 Primary Port
+ */
+public interface PostStatsManager {
+    void initializePostStats(Long postId);
+
+    void incrementViewCount(Long postId);
+
+    void incrementLikeCount(Long postId);
+
+    void decrementLikeCount(Long postId);
+
+    void incrementCommentCount(Long postId);
+
+    void decrementCommentCount(Long postId);
+
+    Optional<PostStats> getPostStats(Long postId);
+
+    PostStats getPostStatsOrThrow(Long postId);
+}

--- a/src/main/java/dooya/see/application/post/required/PostStatsRepository.java
+++ b/src/main/java/dooya/see/application/post/required/PostStatsRepository.java
@@ -12,4 +12,6 @@ public interface PostStatsRepository extends Repository<PostStats, Long> {
     PostStats save(PostStats postStats);
 
     Optional<PostStats> findByPostId(Long postId);
+
+    long count();
 }

--- a/src/test/java/dooya/see/application/post/PostStatsEventHandlerTest.java
+++ b/src/test/java/dooya/see/application/post/PostStatsEventHandlerTest.java
@@ -1,11 +1,11 @@
 package dooya.see.application.post;
 
 import dooya.see.SeeTestConfiguration;
+import dooya.see.application.post.provided.PostStatsManager;
 import dooya.see.application.post.required.PostStatsRepository;
 import dooya.see.domain.post.PostStats;
 import dooya.see.domain.post.PostStatus;
 import dooya.see.domain.post.event.*;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -19,7 +19,7 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 @SpringBootTest
 @Transactional
 @Import(SeeTestConfiguration.class)
-record PostStatsEventHandlerTest(PostStatsEventHandler postStatsEventHandler, PostStatsRepository postStatsRepository) {
+record PostStatsEventHandlerTest(PostStatsEventHandler postStatsEventHandler, PostStatsManager postStatsManager, PostStatsRepository postStatsRepository) {
     private static final Long POST_ID = 100L;
     private static final Long MEMBER_ID = 1L;
     private static final Long ANOTHER_MEMBER_ID = 2L;
@@ -49,7 +49,7 @@ record PostStatsEventHandlerTest(PostStatsEventHandler postStatsEventHandler, Po
     class 게시물_조회_이벤트 {
         @Test
         void PostViewed_이벤트_처리_시_조회수가_증가한다() {
-            createTestPostStats(POST_ID);
+            postStatsManager.initializePostStats(POST_ID);
             PostViewed event = new PostViewed(POST_ID, MEMBER_ID);
 
             postStatsEventHandler.handlePostViewed(event);
@@ -59,7 +59,7 @@ record PostStatsEventHandlerTest(PostStatsEventHandler postStatsEventHandler, Po
 
         @Test
         void 익명_사용자의_PostViewed_이벤트도_정상_처리된다() {
-            createTestPostStats(POST_ID);
+            postStatsManager.initializePostStats(POST_ID);
             PostViewed event = new PostViewed(POST_ID, null);
 
             postStatsEventHandler.handlePostViewed(event);
@@ -87,7 +87,7 @@ record PostStatsEventHandlerTest(PostStatsEventHandler postStatsEventHandler, Po
     class 게시물_좋아요_이벤트 {
         @Test
         void PostLiked_이벤트_처리_시_좋아요_수가_증가한다() {
-            createTestPostStats(POST_ID);
+            postStatsManager.initializePostStats(POST_ID);
             PostLiked event = new PostLiked(POST_ID, MEMBER_ID);
 
             postStatsEventHandler.handlePostLiked(event);
@@ -97,8 +97,8 @@ record PostStatsEventHandlerTest(PostStatsEventHandler postStatsEventHandler, Po
 
         @Test
         void PostUnliked_이벤트_처리_시_좋아요_수가_감소한다() {
-            PostStats stats = createTestPostStats(POST_ID);
-            stats.incrementLikeCount();
+            postStatsManager.initializePostStats(POST_ID);
+            postStatsManager.incrementLikeCount(POST_ID);
             PostUnliked event = new PostUnliked(POST_ID, MEMBER_ID);
 
             postStatsEventHandler.handlePostUnliked(event);
@@ -108,7 +108,7 @@ record PostStatsEventHandlerTest(PostStatsEventHandler postStatsEventHandler, Po
 
         @Test
         void 좋아요_수가_0일_때_PostUnliked_이벤트_처리해도_음수가_되지_않는다() {
-            createTestPostStats(POST_ID);
+            postStatsManager.initializePostStats(POST_ID);
             PostUnliked event = new PostUnliked(POST_ID, MEMBER_ID);
 
             postStatsEventHandler.handlePostUnliked(event);
@@ -121,6 +121,16 @@ record PostStatsEventHandlerTest(PostStatsEventHandler postStatsEventHandler, Po
             PostLiked event = new PostLiked(NON_EXISTENT_POST_ID, MEMBER_ID);
 
             assertThatCode(() -> postStatsEventHandler.handlePostLiked(event))
+                    .doesNotThrowAnyException();
+
+            assertThat(postStatsRepository.findByPostId(NON_EXISTENT_POST_ID)).isEmpty();
+        }
+
+        @Test
+        void 존재하지_않는_게시물의_PostUnliked_이벤트는_조용히_무시된다() {
+            PostUnliked event = new PostUnliked(NON_EXISTENT_POST_ID, MEMBER_ID);
+
+            assertThatCode(() -> postStatsEventHandler.handlePostUnliked(event))
                     .doesNotThrowAnyException();
 
             assertThat(postStatsRepository.findByPostId(NON_EXISTENT_POST_ID)).isEmpty();
@@ -148,7 +158,7 @@ record PostStatsEventHandlerTest(PostStatsEventHandler postStatsEventHandler, Po
     class 복합_이벤트_처리 {
         @Test
         void 여러_이벤트를_순차적으로_처리할_수_있다() {
-            createTestPostStats(POST_ID);
+            postStatsManager.initializePostStats(POST_ID);
 
             processMultipleEvents(POST_ID);
 
@@ -229,11 +239,5 @@ record PostStatsEventHandlerTest(PostStatsEventHandler postStatsEventHandler, Po
             postStatsEventHandler.handlePostLiked(likeEvent);
             postStatsEventHandler.handlePostUnliked(unlikeEvent);
         }
-    }
-
-    // 헬퍼 메서드들
-    private PostStats createTestPostStats(Long postId) {
-        PostStats stats = PostStats.create(postId);
-        return postStatsRepository.save(stats);
     }
 }

--- a/src/test/java/dooya/see/application/post/provided/PostStatsManagerTest.java
+++ b/src/test/java/dooya/see/application/post/provided/PostStatsManagerTest.java
@@ -1,0 +1,398 @@
+package dooya.see.application.post.provided;
+
+import dooya.see.SeeTestConfiguration;
+import dooya.see.application.post.required.PostStatsRepository;
+import dooya.see.domain.post.PostStats;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+@Import(SeeTestConfiguration.class)
+record PostStatsManagerTest(PostStatsManager postStatsManager, PostStatsRepository postStatsRepository) {
+    private static final Long POST_ID = 100L;
+    private static final Long ANOTHER_POST_ID = 200L;
+    private static final Long NON_EXISTENT_POST_ID = 999L;
+
+    @Nested
+    class 통계_초기화 {
+        @Test
+        void 게시물_통계를_초기화할_수_있다() {
+            postStatsManager.initializePostStats(POST_ID);
+
+            assertThatStatsInitialized(POST_ID);
+        }
+
+        @Test
+        void 이미_존재하는_게시물_통계는_중복_생성되지_않는다() {
+            postStatsManager.initializePostStats(POST_ID);
+            long initialCount = postStatsRepository.count();
+
+            postStatsManager.initializePostStats(POST_ID);
+
+            assertThatNoDuplicateStatsCreated(initialCount);
+            assertThatStatsExistsFor(POST_ID);
+        }
+    }
+
+    @Nested
+    class 조회수_관리 {
+        @Test
+        void 조회수를_증가시킬_수_있다() {
+            initializeTestStats(POST_ID);
+
+            postStatsManager.incrementViewCount(POST_ID);
+
+            assertThatViewCountIs(POST_ID, 1);
+        }
+
+        @Test
+        void 조회수를_여러_번_증가시킬_수_있다() {
+            initializeTestStats(POST_ID);
+
+            incrementViewCountTimes(POST_ID, 3);
+
+            assertThatViewCountIs(POST_ID, 3);
+        }
+
+        @Test
+        void 존재하지_않는_게시물의_조회수_증가는_조용히_무시된다() {
+            assertThatOperationDoesNotFail(() -> postStatsManager.incrementViewCount(NON_EXISTENT_POST_ID));
+            assertThatStatsDoesNotExistFor(NON_EXISTENT_POST_ID);
+        }
+    }
+
+    @Nested
+    class 좋아요_관리 {
+        @Test
+        void 좋아요_수를_증가시킬_수_있다() {
+            initializeTestStats(POST_ID);
+
+            postStatsManager.incrementLikeCount(POST_ID);
+
+            assertThatLikeCountIs(POST_ID, 1);
+            assertThatOnlyLikeCountChanged(POST_ID);
+        }
+
+        @Test
+        void 좋아요_수를_감소시킬_수_있다() {
+            initializeTestStats(POST_ID);
+            incrementLikeCountTimes(POST_ID, 2);
+
+            postStatsManager.decrementLikeCount(POST_ID);
+
+            assertThatLikeCountIs(POST_ID, 1);
+        }
+
+        @Test
+        void 좋아요_수가_0일_때_감소시켜도_음수가_되지_않는다() {
+            initializeTestStats(POST_ID);
+
+            postStatsManager.decrementLikeCount(POST_ID);
+
+            assertThatLikeCountRemainsSafe(POST_ID);
+        }
+
+        @Test
+        void 존재하지_않는_게시물의_좋아요_증가는_조용히_무시된다() {
+            assertThatOperationDoesNotFail(() -> postStatsManager.incrementLikeCount(NON_EXISTENT_POST_ID));
+            assertThatStatsDoesNotExistFor(NON_EXISTENT_POST_ID);
+        }
+
+        @Test
+        void 존재하지_않는_게시물의_좋아요_감소는_조용히_무시된다() {
+            assertThatOperationDoesNotFail(() -> postStatsManager.decrementLikeCount(NON_EXISTENT_POST_ID));
+            assertThatStatsDoesNotExistFor(NON_EXISTENT_POST_ID);
+        }
+    }
+
+    @Nested
+    class 댓글_수_관리 {
+        @Test
+        void 댓글_수를_증가시킬_수_있다() {
+            initializeTestStats(POST_ID);
+
+            postStatsManager.incrementCommentCount(POST_ID);
+
+            assertThatCommentCountIs(POST_ID, 1);
+            assertThatOnlyCommentCountChanged(POST_ID);
+        }
+
+        @Test
+        void 댓글_수를_감소시킬_수_있다() {
+            initializeTestStats(POST_ID);
+            incrementCommentCountTimes(POST_ID, 2);
+
+            postStatsManager.decrementCommentCount(POST_ID);
+
+            assertThatCommentCountIs(POST_ID, 1);
+        }
+
+        @Test
+        void 댓글_수가_0일_때_감소시켜도_음수가_되지_않는다() {
+            initializeTestStats(POST_ID);
+
+            postStatsManager.decrementCommentCount(POST_ID);
+
+            assertThatCommentCountRemainsSafe(POST_ID);
+        }
+
+        @Test
+        void 존재하지_않는_게시물의_댓글_수_증가는_조용히_무시된다() {
+            assertThatOperationDoesNotFail(() -> postStatsManager.incrementCommentCount(NON_EXISTENT_POST_ID));
+            assertThatStatsDoesNotExistFor(NON_EXISTENT_POST_ID);
+        }
+
+        @Test
+        void 존재하지_않는_게시물의_댓글_수_감소는_조용히_무시된다() {
+            assertThatOperationDoesNotFail(() -> postStatsManager.decrementCommentCount(NON_EXISTENT_POST_ID));
+            assertThatStatsDoesNotExistFor(NON_EXISTENT_POST_ID);
+        }
+    }
+
+    @Nested
+    class 통계_조회 {
+        @Test
+        void 게시물_통계를_조회할_수_있다() {
+            setupCompleteStats(POST_ID);
+
+            Optional<PostStats> result = postStatsManager.getPostStats(POST_ID);
+
+            assertThatStatsFound(result);
+            assertThatCompleteStatsCorrect(result.get());
+        }
+
+        @Test
+        void 존재하지_않는_게시물_통계_조회_시_Empty를_반환한다() {
+            Optional<PostStats> result = postStatsManager.getPostStats(NON_EXISTENT_POST_ID);
+
+            assertThatStatsNotFound(result);
+        }
+
+        @Test
+        void getPostStatsOrThrow로_게시물_통계를_조회할_수_있다() {
+            initializeTestStats(POST_ID);
+            postStatsManager.incrementViewCount(POST_ID);
+
+            PostStats stats = postStatsManager.getPostStatsOrThrow(POST_ID);
+
+            assertThatStatsFoundWithPostId(stats, POST_ID);
+            assertThatViewCountIs(stats, 1);
+        }
+
+        @Test
+        void getPostStatsOrThrow로_존재하지_않는_게시물_조회_시_예외가_발생한다() {
+            assertThatThrownBy(() -> postStatsManager.getPostStatsOrThrow(NON_EXISTENT_POST_ID))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("PostStats not found for postId: " + NON_EXISTENT_POST_ID);
+        }
+    }
+
+    @Nested
+    class 복합_시나리오 {
+        @Test
+        void 모든_통계를_종합적으로_관리할_수_있다() {
+            initializeTestStats(POST_ID);
+
+            performComprehensiveStatsOperations(POST_ID);
+
+            assertThatComprehensiveStatsCorrect(POST_ID);
+        }
+
+        @Test
+        void 여러_게시물의_통계를_독립적으로_관리할_수_있다() {
+            setupIndependentPostStats();
+
+            assertThatIndependentStatsCorrect();
+        }
+
+        @Test
+        void 도메인_로직을_활용한_통계_분석이_가능하다() {
+            initializeTestStats(POST_ID);
+            setupPopularPostStats(POST_ID);
+
+            PostStats stats = postStatsManager.getPostStatsOrThrow(POST_ID);
+
+            assertThatPostIsPopular(stats);
+            assertThatPostHasEngagement(stats);
+            assertThatStatsAreValid(stats);
+        }
+    }
+
+    // 헬퍼 메서드들
+    private void initializeTestStats(Long postId) {
+        postStatsManager.initializePostStats(postId);
+    }
+
+    private void incrementViewCountTimes(Long postId, int times) {
+        for (int i = 0; i < times; i++)
+            postStatsManager.incrementViewCount(postId);
+    }
+
+    private void incrementLikeCountTimes(Long postId, int times) {
+        for (int i = 0; i < times; i++)
+            postStatsManager.incrementLikeCount(postId);
+    }
+
+    private void incrementCommentCountTimes(Long postId, int times) {
+        for (int i = 0; i < times; i++)
+            postStatsManager.incrementCommentCount(postId);
+    }
+
+    private void setupCompleteStats(Long postId) {
+        initializeTestStats(postId);
+        postStatsManager.incrementViewCount(postId);
+        postStatsManager.incrementLikeCount(postId);
+        postStatsManager.incrementCommentCount(postId);
+    }
+
+    private void performComprehensiveStatsOperations(Long postId) {
+        incrementViewCountTimes(postId, 3);
+        incrementLikeCountTimes(postId, 2);
+        postStatsManager.decrementLikeCount(postId);
+        postStatsManager.incrementCommentCount(postId);
+    }
+
+    private void setupIndependentPostStats() {
+        initializeTestStats(POST_ID);
+        initializeTestStats(ANOTHER_POST_ID);
+
+        postStatsManager.incrementViewCount(POST_ID);
+        postStatsManager.incrementLikeCount(POST_ID);
+
+        incrementViewCountTimes(ANOTHER_POST_ID, 2);
+        postStatsManager.incrementCommentCount(ANOTHER_POST_ID);
+    }
+
+    private void setupPopularPostStats(Long postId) {
+        incrementViewCountTimes(postId, 1000);
+        incrementLikeCountTimes(postId, 50);
+        incrementCommentCountTimes(postId, 10);
+    }
+
+    // 검증 메서드들
+    private void assertThatStatsInitialized(Long postId) {
+        PostStats stats = postStatsRepository.findByPostId(postId).orElseThrow();
+        assertThat(stats.getPostId()).isEqualTo(postId);
+        assertThat(stats.getViewCount()).isEqualTo(0);
+        assertThat(stats.getLikeCount()).isEqualTo(0);
+        assertThat(stats.getCommentCount()).isEqualTo(0);
+    }
+
+    private void assertThatNoDuplicateStatsCreated(long initialCount) {
+        assertThat(postStatsRepository.count()).isEqualTo(initialCount);
+    }
+
+    private void assertThatStatsExistsFor(Long postId) {
+        PostStats stats = postStatsRepository.findByPostId(postId).orElseThrow();
+        assertThat(stats.getPostId()).isEqualTo(postId);
+    }
+
+    private void assertThatViewCountIs(Long postId, int expectedCount) {
+        PostStats stats = postStatsRepository.findByPostId(postId).orElseThrow();
+        assertThat(stats.getViewCount()).isEqualTo(expectedCount);
+    }
+
+    private void assertThatViewCountIs(PostStats stats, int expectedCount) {
+        assertThat(stats.getViewCount()).isEqualTo(expectedCount);
+    }
+
+    private void assertThatLikeCountIs(Long postId, int expectedCount) {
+        PostStats stats = postStatsRepository.findByPostId(postId).orElseThrow();
+        assertThat(stats.getLikeCount()).isEqualTo(expectedCount);
+    }
+
+    private void assertThatLikeCountRemainsSafe(Long postId) {
+        PostStats stats = postStatsRepository.findByPostId(postId).orElseThrow();
+        assertThat(stats.getLikeCount()).isEqualTo(0);
+    }
+
+    private void assertThatCommentCountIs(Long postId, int expectedCount) {
+        PostStats stats = postStatsRepository.findByPostId(postId).orElseThrow();
+        assertThat(stats.getCommentCount()).isEqualTo(expectedCount);
+    }
+
+    private void assertThatCommentCountRemainsSafe(Long postId) {
+        PostStats stats = postStatsRepository.findByPostId(postId).orElseThrow();
+        assertThat(stats.getCommentCount()).isEqualTo(0);
+    }
+
+    private void assertThatOnlyLikeCountChanged(Long postId) {
+        PostStats stats = postStatsRepository.findByPostId(postId).orElseThrow();
+        assertThat(stats.getViewCount()).isEqualTo(0);
+        assertThat(stats.getCommentCount()).isEqualTo(0);
+    }
+
+    private void assertThatOnlyCommentCountChanged(Long postId) {
+        PostStats stats = postStatsRepository.findByPostId(postId).orElseThrow();
+        assertThat(stats.getViewCount()).isEqualTo(0);
+        assertThat(stats.getLikeCount()).isEqualTo(0);
+    }
+
+    private void assertThatOperationDoesNotFail(Runnable operation) {
+        assertThatCode(operation::run).doesNotThrowAnyException();
+    }
+
+    private void assertThatStatsDoesNotExistFor(Long postId) {
+        assertThat(postStatsRepository.findByPostId(postId)).isEmpty();
+    }
+
+    private void assertThatStatsFound(Optional<PostStats> result) {
+        assertThat(result).isPresent();
+    }
+
+    private void assertThatStatsNotFound(Optional<PostStats> result) {
+        assertThat(result).isEmpty();
+    }
+
+    private void assertThatCompleteStatsCorrect(PostStats stats) {
+        assertThat(stats.getPostId()).isEqualTo(POST_ID);
+        assertThat(stats.getViewCount()).isEqualTo(1);
+        assertThat(stats.getLikeCount()).isEqualTo(1);
+        assertThat(stats.getCommentCount()).isEqualTo(1);
+    }
+
+    private void assertThatStatsFoundWithPostId(PostStats stats, Long expectedPostId) {
+        assertThat(stats.getPostId()).isEqualTo(expectedPostId);
+    }
+
+    private void assertThatComprehensiveStatsCorrect(Long postId) {
+        PostStats stats = postStatsManager.getPostStatsOrThrow(postId);
+        assertThat(stats.getViewCount()).isEqualTo(3);
+        assertThat(stats.getLikeCount()).isEqualTo(1);
+        assertThat(stats.getCommentCount()).isEqualTo(1);
+    }
+
+    private void assertThatIndependentStatsCorrect() {
+        PostStats stats1 = postStatsManager.getPostStatsOrThrow(POST_ID);
+        assertThat(stats1.getViewCount()).isEqualTo(1);
+        assertThat(stats1.getLikeCount()).isEqualTo(1);
+        assertThat(stats1.getCommentCount()).isEqualTo(0);
+
+        PostStats stats2 = postStatsManager.getPostStatsOrThrow(ANOTHER_POST_ID);
+        assertThat(stats2.getViewCount()).isEqualTo(2);
+        assertThat(stats2.getLikeCount()).isEqualTo(0);
+        assertThat(stats2.getCommentCount()).isEqualTo(1);
+    }
+
+    private void assertThatPostIsPopular(PostStats stats) {
+        assertThat(stats.isPopular()).isTrue();
+        assertThat(stats.isViral()).isFalse();
+    }
+
+    private void assertThatPostHasEngagement(PostStats stats) {
+        assertThat(stats.hasEngagement()).isTrue();
+        assertThat(stats.getEngagementRate()).isGreaterThan(0);
+    }
+
+    private void assertThatStatsAreValid(PostStats stats) {
+        assertThat(stats.hasValidStats()).isTrue();
+    }
+}


### PR DESCRIPTION
## 📌 Issue

<!-- 해결하려는 이슈 번호나 주제를 명확하게 적어주세요. -->

- closed #141 

---

## 🧐 현재 상황

<!-- 현재 발생한 문제, 개선이 필요한 사항을 간략히 설명해주세요. -->

- @EventListener 사용으로 메인 트랜잭션 내에서 동기적으로 사이드 이펙트 처리
- 통계 처리 실패 시 전체 트랜잭션 롤백 위험
- Repository 직접 접근으로 인한 관심사 분리 부족
- 예외 처리 누락으로 장애 전파 가능성

---

## 🎯 목표

<!-- 이슈를 통해 달성하고자 하는 목표를 설명해주세요. -->

- 도메인 이벤트 처리를 메인 트랜잭션과 분리하여 안전성 확보
- 사이드 이펙트 실패가 핵심 비즈니스 로직에 영향주지 않도록 개선
- PostStatsManager 인터페이스 도입으로 관심사 분리 및 캡슐화 강화

---

## 🛠 작업 내용

- 작업 할 내용을 입력해주세요.

- [x]  @EventListener → @TransactionalEventListener(AFTER_COMMIT) 변경
- [x]  @Async 어노테이션 추가로 비동기 처리 구현
- [x]  PostStatsManager 인터페이스 도입으로 통계 로직 캡슐화
- [x]  try-catch 블록 추가로 각 이벤트 핸들러별 예외 격리
- [x]  클래스 레벨 @Transactional 제거 및 의존성 정리
- [x] 테스트 작성

---

## 🚀 기타 사항

<!-- 리뷰어가 추가적으로 알아야 할 사항이 있다면 기재해주세요. -->

- 추가적인 내용을 작성해주세요.(참고 자료, 협업 내용)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 게시물 조회수/좋아요/댓글 수 통계 반영 로직을 개선하여 정확도를 높였습니다.
- 버그 수정
  - 존재하지 않는 게시물에 대한 이벤트를 무시하여 잘못된 통계 생성/갱신을 방지했습니다.
  - 중복 초기화 및 음수 카운트 발생 가능성을 제거했습니다.
- 리팩터
  - 이벤트 기반 통계 반영을 커밋 이후 비동기로 처리해 반응성과 안정성을 개선했습니다.
- 테스트
  - 통계 초기화, 조회, 증가/감소 시나리오 전반에 대한 종합 테스트를 추가해 신뢰성을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->