### PR TITLE
Post 검색 Elasticsearch 도입

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,21 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
+    services:
+      elasticsearch:
+        image: docker.elastic.co/elasticsearch/elasticsearch:8.13.4
+        ports:
+          - 9200:9200
+        env:
+          discovery.type: single-node
+          ES_JAVA_OPTS: "-Xms512m -Xmx512m"
+          xpack.security.enabled: "false"
+        options: >-
+          --health-cmd "curl -f http://localhost:9200/_cluster/health || exit 1"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -35,13 +50,11 @@ jobs:
           mkdir -p ./src/main/resources
           echo "${{ secrets.APPLICATION_YML }}" > ./src/main/resources/application.yml
 
-      # IPv6 비활성화 (네트워크 오류 방지)
       - name: Disable IPv6
         run: |
           sudo sysctl -w net.ipv6.conf.all.disable_ipv6=1
           sudo sysctl -w net.ipv6.conf.default.disable_ipv6=1
 
-      # Gradle Wrapper 검증 (보안)
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@v2
         with:
@@ -64,6 +77,18 @@ jobs:
           gradle-build-scan-report: true
           cache-read-only: false
 
+      - name: Wait for Elasticsearch to be ready
+        run: |
+          echo "Waiting for Elasticsearch..."
+          for i in {1..20}; do
+            if curl -s http://localhost:9200 >/dev/null; then
+              echo "Elasticsearch is up!"
+              break
+            fi
+            echo "Retrying in 3s..."
+            sleep 3
+          done
+
       - name: Run tests
         run: |
           ./gradlew clean test \
@@ -73,6 +98,8 @@ jobs:
             --daemon \
             -Dorg.gradle.jvmargs="-Xmx2g -XX:+UseParallelGC" \
             -Dspring.profiles.active=test
+        env:
+          SPRING_ELASTICSEARCH_URIS: http://localhost:9200
 
       - name: Upload test results
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,13 +81,15 @@ jobs:
         run: |
           echo "Waiting for Elasticsearch..."
           for i in {1..20}; do
-            if curl -s http://localhost:9200 >/dev/null; then
+            if curl -fsS http://localhost:9200 >/dev/null; then
               echo "Elasticsearch is up!"
-              break
+              exit 0
             fi
-            echo "Retrying in 3s..."
-            sleep 3
-          done
+              echo "Retrying in 3s..."
+              sleep 3
+            done
+            echo "Elasticsearch did not become ready in time."
+            exit 1
 
       - name: Run tests
         run: |

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,6 +29,7 @@ val mockitoAgent: Configuration = configurations.create("mockitoAgent")
 
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    implementation("org.springframework.boot:spring-boot-starter-data-elasticsearch")
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework.security:spring-security-core")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,24 +19,55 @@ services:
       retries: 10
     restart: unless-stopped
 
-  mysql-test:
-    image: mysql:8.0
-    container_name: see-test-mysql
-    ports:
-      - "3307:3306"
+#  mysql-test:
+#    image: mysql:8.0
+#    container_name: see-test-mysql
+#    ports:
+#      - "3307:3306"
+#    environment:
+#      MYSQL_ROOT_PASSWORD: root
+#      MYSQL_DATABASE: see_test
+#      MYSQL_USER: see_user
+#      MYSQL_PASSWORD: see_password
+#    volumes:
+#      - mysql_test_data:/var/lib/mysql
+#      - ./docker/mysql/init:/docker-entrypoint-initdb.d
+#    command: --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
+#    restart: unless-stopped
+
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.12.0
+    container_name: see-elasticsearch
     environment:
-      MYSQL_ROOT_PASSWORD: root
-      MYSQL_DATABASE: see_test
-      MYSQL_USER: see_user
-      MYSQL_PASSWORD: see_password
+      - discovery.type=single-node
+      - xpack.security.enabled=false
+      - ES_JAVA_OPTS=-Xms1g -Xmx1g
+    ports:
+      - "9200:9200"
     volumes:
-      - mysql_test_data:/var/lib/mysql
-      - ./docker/mysql/init:/docker-entrypoint-initdb.d
-    command: --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
+      - es_data:/usr/share/elasticsearch/data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9200"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
+  kibana:
+    image: docker.elastic.co/kibana/kibana:8.12.0
+    container_name: see-kibana
+    ports:
+      - "5601:5601"
+    environment:
+      ELASTICSEARCH_HOSTS: http://see-elasticsearch:9200
+    depends_on:
+      - elasticsearch
     restart: unless-stopped
 
 volumes:
   mysql_data:
     driver: local
   mysql_test_data:
+  es_data:
+    driver: local
 

--- a/src/main/java/dooya/see/adapter/search/PostDocument.java
+++ b/src/main/java/dooya/see/adapter/search/PostDocument.java
@@ -1,0 +1,44 @@
+package dooya.see.adapter.search;
+
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Document(indexName = "posts")
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostDocument {
+    @Id
+    private Long id;
+
+    @Field(type = FieldType.Text)
+    private String title;
+
+    @Field(type = FieldType.Text)
+    private String content;
+
+    @Field(type = FieldType.Keyword)
+    private String category;
+
+    @Field(type = FieldType.Long)
+    private Long memberId;
+
+    @Field(type = FieldType.Keyword)
+    private List<String> tags;
+
+    @Field(type = FieldType.Date)
+    private LocalDateTime createdAt;
+
+    @Field(type = FieldType.Date)
+    private LocalDateTime modifiedAt;
+}

--- a/src/main/java/dooya/see/adapter/search/elasticsearch/PostSearchElasticsearchAdapter.java
+++ b/src/main/java/dooya/see/adapter/search/elasticsearch/PostSearchElasticsearchAdapter.java
@@ -35,6 +35,6 @@ public class PostSearchElasticsearchAdapter implements PostSearchIndexer {
 
     @Override
     public void delete(Long postId) {
-        repository.deleteById(postId);
+        repository.deleteById(String.valueOf(postId));
     }
 }

--- a/src/main/java/dooya/see/adapter/search/elasticsearch/PostSearchElasticsearchAdapter.java
+++ b/src/main/java/dooya/see/adapter/search/elasticsearch/PostSearchElasticsearchAdapter.java
@@ -3,7 +3,9 @@ package dooya.see.adapter.search.elasticsearch;
 import dooya.see.adapter.search.elasticsearch.document.PostDocument;
 import dooya.see.adapter.search.elasticsearch.mapper.PostDocumentMapper;
 import dooya.see.adapter.search.elasticsearch.repository.PostSearchElasticsearchRepository;
+import dooya.see.application.member.required.MemberRepository;
 import dooya.see.application.post.required.PostSearchIndexer;
+import dooya.see.domain.member.Member;
 import dooya.see.domain.post.Post;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -13,10 +15,15 @@ import org.springframework.stereotype.Component;
 public class PostSearchElasticsearchAdapter implements PostSearchIndexer {
     private final PostSearchElasticsearchRepository repository;
     private final PostDocumentMapper mapper;
+    private final MemberRepository memberRepository;
 
     @Override
     public void index(Post post) {
-        PostDocument document = mapper.toDocument(post);
+        String nickname = memberRepository.findById(post.getMemberId())
+                .map(Member::getNickname)
+                .orElse("");
+
+        PostDocument document = mapper.toDocument(post, nickname);
         repository.save(document);
     }
 

--- a/src/main/java/dooya/see/adapter/search/elasticsearch/PostSearchElasticsearchAdapter.java
+++ b/src/main/java/dooya/see/adapter/search/elasticsearch/PostSearchElasticsearchAdapter.java
@@ -1,16 +1,18 @@
 package dooya.see.adapter.search.elasticsearch;
 
-import dooya.see.adapter.search.elasticsearch.document.PostDocument;
 import dooya.see.adapter.search.elasticsearch.mapper.PostDocumentMapper;
 import dooya.see.adapter.search.elasticsearch.repository.PostSearchElasticsearchRepository;
 import dooya.see.application.member.required.MemberRepository;
 import dooya.see.application.post.required.PostSearchIndexer;
-import dooya.see.domain.member.Member;
 import dooya.see.domain.post.Post;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import static java.util.Objects.requireNonNull;
+import lombok.extern.slf4j.Slf4j;
+
 @Component
+@Slf4j
 @RequiredArgsConstructor
 public class PostSearchElasticsearchAdapter implements PostSearchIndexer {
     private final PostSearchElasticsearchRepository repository;
@@ -19,12 +21,16 @@ public class PostSearchElasticsearchAdapter implements PostSearchIndexer {
 
     @Override
     public void index(Post post) {
-        String nickname = memberRepository.findById(post.getMemberId())
-                .map(Member::getNickname)
-                .orElse("");
+        requireNonNull(post, "post must not be null");
 
-        PostDocument document = mapper.toDocument(post, nickname);
-        repository.save(document);
+        String nickname = memberRepository.findById(post.getMemberId())
+                .map(member -> member.getNickname() != null ? member.getNickname() : "")
+                .orElseGet(() -> {
+                    log.warn("회원 ID={} 을(를) 찾을 수 없어 빈 닉네임으로 색인합니다", post.getMemberId());
+                    return "";
+                });
+
+        repository.save(mapper.toDocument(post, nickname));
     }
 
     @Override

--- a/src/main/java/dooya/see/adapter/search/elasticsearch/PostSearchElasticsearchAdapter.java
+++ b/src/main/java/dooya/see/adapter/search/elasticsearch/PostSearchElasticsearchAdapter.java
@@ -1,0 +1,27 @@
+package dooya.see.adapter.search.elasticsearch;
+
+import dooya.see.adapter.search.elasticsearch.document.PostDocument;
+import dooya.see.adapter.search.elasticsearch.mapper.PostDocumentMapper;
+import dooya.see.adapter.search.elasticsearch.repository.PostSearchElasticsearchRepository;
+import dooya.see.application.post.required.PostSearchIndexer;
+import dooya.see.domain.post.Post;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PostSearchElasticsearchAdapter implements PostSearchIndexer {
+    private final PostSearchElasticsearchRepository repository;
+    private final PostDocumentMapper mapper;
+
+    @Override
+    public void index(Post post) {
+        PostDocument document = mapper.toDocument(post);
+        repository.save(document);
+    }
+
+    @Override
+    public void delete(Long postId) {
+        repository.deleteById(postId);
+    }
+}

--- a/src/main/java/dooya/see/adapter/search/elasticsearch/PostSearchElasticsearchReaderAdapter.java
+++ b/src/main/java/dooya/see/adapter/search/elasticsearch/PostSearchElasticsearchReaderAdapter.java
@@ -1,0 +1,24 @@
+package dooya.see.adapter.search.elasticsearch;
+
+import dooya.see.adapter.search.elasticsearch.document.PostDocument;
+import dooya.see.adapter.search.elasticsearch.mapper.PostDocumentMapper;
+import dooya.see.adapter.search.elasticsearch.repository.PostSearchElasticsearchRepository;
+import dooya.see.application.post.required.PostSearchReader;
+import dooya.see.domain.post.Post;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PostSearchElasticsearchReaderAdapter implements PostSearchReader {
+    private final PostSearchElasticsearchRepository repository;
+    private final PostDocumentMapper mapper;
+
+    @Override
+    public Page<Post> searchByKeyword(String keyword, Pageable pageable) {
+        Page<PostDocument> result = repository.findByTitleContainingOrContentContaining(keyword, keyword, pageable);
+        return result.map(mapper::toDomain);
+    }
+}

--- a/src/main/java/dooya/see/adapter/search/elasticsearch/PostSearchElasticsearchReaderAdapter.java
+++ b/src/main/java/dooya/see/adapter/search/elasticsearch/PostSearchElasticsearchReaderAdapter.java
@@ -17,8 +17,7 @@ public class PostSearchElasticsearchReaderAdapter implements PostSearchReader {
     private final PostDocumentMapper mapper;
 
     @Override
-    public Page<Post> searchByKeyword(String keyword, Pageable pageable) {
-        Page<PostDocument> result = repository.findByTitleContainingOrContentContaining(keyword, keyword, pageable);
-        return result.map(mapper::toDomain);
+    public Page<PostDocument> searchByKeyword(String keyword, Pageable pageable) {
+        return repository.findByTitleContainingOrContentContaining(keyword, keyword, pageable);
     }
 }

--- a/src/main/java/dooya/see/adapter/search/elasticsearch/PostSearchElasticsearchReaderAdapter.java
+++ b/src/main/java/dooya/see/adapter/search/elasticsearch/PostSearchElasticsearchReaderAdapter.java
@@ -4,7 +4,7 @@ import dooya.see.adapter.search.elasticsearch.document.PostDocument;
 import dooya.see.adapter.search.elasticsearch.mapper.PostDocumentMapper;
 import dooya.see.adapter.search.elasticsearch.repository.PostSearchElasticsearchRepository;
 import dooya.see.application.post.required.PostSearchReader;
-import dooya.see.domain.post.Post;
+import dooya.see.application.post.dto.PostSearchResult;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -17,7 +17,8 @@ public class PostSearchElasticsearchReaderAdapter implements PostSearchReader {
     private final PostDocumentMapper mapper;
 
     @Override
-    public Page<PostDocument> searchByKeyword(String keyword, Pageable pageable) {
-        return repository.findByTitleContainingOrContentContaining(keyword, keyword, pageable);
+    public Page<PostSearchResult> searchByKeyword(String keyword, Pageable pageable) {
+        Page<PostDocument> result = repository.findByTitleContainingOrContentContaining(keyword, keyword, pageable);
+        return result.map(mapper::toSearchResult);
     }
 }

--- a/src/main/java/dooya/see/adapter/search/elasticsearch/document/PostDocument.java
+++ b/src/main/java/dooya/see/adapter/search/elasticsearch/document/PostDocument.java
@@ -34,6 +34,9 @@ public class PostDocument {
     private Long memberId;
 
     @Field(type = FieldType.Keyword)
+    private String authorNickname;
+
+    @Field(type = FieldType.Keyword)
     private List<String> tags;
 
     @Field(type = FieldType.Date)

--- a/src/main/java/dooya/see/adapter/search/elasticsearch/document/PostDocument.java
+++ b/src/main/java/dooya/see/adapter/search/elasticsearch/document/PostDocument.java
@@ -19,7 +19,7 @@ import java.util.List;
 @AllArgsConstructor
 public class PostDocument {
     @Id
-    private Long id;
+    private String id;
 
     @Field(type = FieldType.Text)
     private String title;

--- a/src/main/java/dooya/see/adapter/search/elasticsearch/document/PostDocument.java
+++ b/src/main/java/dooya/see/adapter/search/elasticsearch/document/PostDocument.java
@@ -38,7 +38,4 @@ public class PostDocument {
 
     @Field(type = FieldType.Date)
     private LocalDate createdAt;
-
-    @Field(type = FieldType.Date)
-    private LocalDate modifiedAt;
 }

--- a/src/main/java/dooya/see/adapter/search/elasticsearch/document/PostDocument.java
+++ b/src/main/java/dooya/see/adapter/search/elasticsearch/document/PostDocument.java
@@ -1,10 +1,10 @@
 package dooya.see.adapter.search.elasticsearch.document;
 
-import jakarta.persistence.Id;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
 import org.springframework.data.elasticsearch.annotations.Document;
 import org.springframework.data.elasticsearch.annotations.Field;
 import org.springframework.data.elasticsearch.annotations.FieldType;

--- a/src/main/java/dooya/see/adapter/search/elasticsearch/document/PostDocument.java
+++ b/src/main/java/dooya/see/adapter/search/elasticsearch/document/PostDocument.java
@@ -9,7 +9,7 @@ import org.springframework.data.elasticsearch.annotations.Document;
 import org.springframework.data.elasticsearch.annotations.Field;
 import org.springframework.data.elasticsearch.annotations.FieldType;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.List;
 
 @Document(indexName = "posts")
@@ -37,8 +37,8 @@ public class PostDocument {
     private List<String> tags;
 
     @Field(type = FieldType.Date)
-    private LocalDateTime createdAt;
+    private LocalDate createdAt;
 
     @Field(type = FieldType.Date)
-    private LocalDateTime modifiedAt;
+    private LocalDate modifiedAt;
 }

--- a/src/main/java/dooya/see/adapter/search/elasticsearch/document/PostDocument.java
+++ b/src/main/java/dooya/see/adapter/search/elasticsearch/document/PostDocument.java
@@ -1,4 +1,4 @@
-package dooya.see.adapter.search;
+package dooya.see.adapter.search.elasticsearch.document;
 
 import jakarta.persistence.Id;
 import lombok.AllArgsConstructor;

--- a/src/main/java/dooya/see/adapter/search/elasticsearch/mapper/PostDocumentMapper.java
+++ b/src/main/java/dooya/see/adapter/search/elasticsearch/mapper/PostDocumentMapper.java
@@ -1,9 +1,11 @@
 package dooya.see.adapter.search.elasticsearch.mapper;
 
 import dooya.see.adapter.search.elasticsearch.document.PostDocument;
+import dooya.see.application.post.dto.PostSearchResult;
 import dooya.see.domain.post.*;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
 import java.util.stream.Collectors;
 
 @Component
@@ -25,5 +27,28 @@ public class PostDocumentMapper {
                         .collect(Collectors.toList()))
                 .createdAt(post.getMetaData().createdAt().toLocalDate())
                 .build();
+    }
+
+    public PostSearchResult toSearchResult(PostDocument document) {
+        if (document == null) {
+            throw new IllegalArgumentException("");
+        }
+
+        PostCategory category = document.getCategory() != null
+                ? PostCategory.valueOf(document.getCategory())
+                : null;
+
+        List<String> tags = document.getTags() != null ? List.copyOf(document.getTags()) : List.of();
+
+        return new PostSearchResult(
+                document.getId() != null ? Long.valueOf(document.getId()) : null,
+                document.getTitle(),
+                document.getContent(),
+                category,
+                document.getMemberId(),
+                document.getAuthorNickname(),
+                tags,
+                document.getCreatedAt()
+        );
     }
 }

--- a/src/main/java/dooya/see/adapter/search/elasticsearch/mapper/PostDocumentMapper.java
+++ b/src/main/java/dooya/see/adapter/search/elasticsearch/mapper/PostDocumentMapper.java
@@ -4,12 +4,11 @@ import dooya.see.adapter.search.elasticsearch.document.PostDocument;
 import dooya.see.domain.post.*;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
 import java.util.stream.Collectors;
 
 @Component
 public class PostDocumentMapper {
-    public PostDocument toDocument(Post post) {
+    public PostDocument toDocument(Post post, String authorNickname) {
         if (post == null) {
             throw new IllegalArgumentException("");
         }
@@ -20,37 +19,11 @@ public class PostDocumentMapper {
                 .content(post.getContent().body())
                 .category(post.getCategory().name())
                 .memberId(post.getMemberId())
+                .authorNickname(authorNickname)
                 .tags(post.getTags().stream()
                         .map(Tag::name)
                         .collect(Collectors.toList()))
                 .createdAt(post.getMetaData().createdAt().toLocalDate())
                 .build();
-
-    }
-
-    public Post toDomain(PostDocument document) {
-        if (document == null) {
-            throw new IllegalArgumentException("");
-        }
-
-        PostMetaData metaData = new PostMetaData(
-                document.getCreatedAt().atStartOfDay(),
-                null,
-                null
-        );
-
-        List<Tag> tags = document.getTags().stream()
-                .map(raw -> new Tag(raw.replace("#", "")))
-                .toList();
-
-        return Post.fromSearchIndex(
-                Long.valueOf(document.getId()),
-                document.getTitle(),
-                document.getContent(),
-                PostCategory.valueOf(document.getCategory()),
-                document.getMemberId(),
-                tags,
-                metaData
-        );
     }
 }

--- a/src/main/java/dooya/see/adapter/search/elasticsearch/mapper/PostDocumentMapper.java
+++ b/src/main/java/dooya/see/adapter/search/elasticsearch/mapper/PostDocumentMapper.java
@@ -2,18 +2,27 @@ package dooya.see.adapter.search.elasticsearch.mapper;
 
 import dooya.see.adapter.search.elasticsearch.document.PostDocument;
 import dooya.see.application.post.dto.PostSearchResult;
-import dooya.see.domain.post.*;
+import dooya.see.domain.post.Post;
+import dooya.see.domain.post.PostCategory;
+import dooya.see.domain.post.PostMetaData;
+import dooya.see.domain.post.Tag;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.time.LocalDate;
+import java.util.List;
 import java.util.stream.Collectors;
+
+import static java.util.Objects.requireNonNull;
 
 @Component
 public class PostDocumentMapper {
     public PostDocument toDocument(Post post, String authorNickname) {
-        if (post == null) {
-            throw new IllegalArgumentException("");
-        }
+        requireNonNull(post, "게시글 정보는 필수입니다");
+        requireNonNull(authorNickname, "작성자 닉네임은 필수입니다");
+
+        PostMetaData metaData = requireNonNull(post.getMetaData(), "게시글 메타데이터가 없습니다");
+        LocalDate createdAt = requireNonNull(metaData.createdAt(), "게시글 생성일이 없습니다").toLocalDate();
 
         return PostDocument.builder()
                 .id(String.valueOf(post.getId()))
@@ -25,13 +34,20 @@ public class PostDocumentMapper {
                 .tags(post.getTags().stream()
                         .map(Tag::name)
                         .collect(Collectors.toList()))
-                .createdAt(post.getMetaData().createdAt().toLocalDate())
+                .createdAt(createdAt)
                 .build();
     }
 
     public PostSearchResult toSearchResult(PostDocument document) {
-        if (document == null) {
-            throw new IllegalArgumentException("");
+        requireNonNull(document, "검색 문서는 필수입니다");
+
+        Long id = null;
+        if (document.getId() != null) {
+            try {
+                id = Long.parseLong(document.getId());
+            } catch (NumberFormatException ex) {
+                throw new IllegalArgumentException("검색 문서 ID는 숫자여야 합니다", ex);
+            }
         }
 
         PostCategory category = document.getCategory() != null
@@ -41,7 +57,7 @@ public class PostDocumentMapper {
         List<String> tags = document.getTags() != null ? List.copyOf(document.getTags()) : List.of();
 
         return new PostSearchResult(
-                document.getId() != null ? Long.valueOf(document.getId()) : null,
+                id,
                 document.getTitle(),
                 document.getContent(),
                 category,

--- a/src/main/java/dooya/see/adapter/search/elasticsearch/mapper/PostDocumentMapper.java
+++ b/src/main/java/dooya/see/adapter/search/elasticsearch/mapper/PostDocumentMapper.java
@@ -1,0 +1,30 @@
+package dooya.see.adapter.search.elasticsearch.mapper;
+
+import dooya.see.adapter.search.elasticsearch.document.PostDocument;
+import dooya.see.domain.post.Post;
+import dooya.see.domain.post.Tag;
+import org.springframework.stereotype.Component;
+
+import java.util.stream.Collectors;
+
+@Component
+public class PostDocumentMapper {
+    public PostDocument toDocument(Post post) {
+        if (post == null) {
+            throw new IllegalArgumentException("");
+        }
+
+        return PostDocument.builder()
+                .id(post.getId())
+                .title(post.getContent().title())
+                .content(post.getContent().body())
+                .category(post.getCategory().name())
+                .memberId(post.getMemberId())
+                .tags(post.getTags().stream()
+                        .map(Tag::displayName)
+                        .collect(Collectors.toList()))
+                .createdAt(post.getMetaData().createdAt().toLocalDate())
+                .build();
+
+    }
+}

--- a/src/main/java/dooya/see/adapter/search/elasticsearch/mapper/PostDocumentMapper.java
+++ b/src/main/java/dooya/see/adapter/search/elasticsearch/mapper/PostDocumentMapper.java
@@ -21,7 +21,7 @@ public class PostDocumentMapper {
                 .category(post.getCategory().name())
                 .memberId(post.getMemberId())
                 .tags(post.getTags().stream()
-                        .map(Tag::displayName)
+                        .map(Tag::name)
                         .collect(Collectors.toList()))
                 .createdAt(post.getMetaData().createdAt().toLocalDate())
                 .build();
@@ -40,7 +40,7 @@ public class PostDocumentMapper {
         );
 
         List<Tag> tags = document.getTags().stream()
-                .map(Tag::new)
+                .map(raw -> new Tag(raw.replace("#", "")))
                 .toList();
 
         return Post.fromSearchIndex(

--- a/src/main/java/dooya/see/adapter/search/elasticsearch/mapper/PostDocumentMapper.java
+++ b/src/main/java/dooya/see/adapter/search/elasticsearch/mapper/PostDocumentMapper.java
@@ -1,10 +1,10 @@
 package dooya.see.adapter.search.elasticsearch.mapper;
 
 import dooya.see.adapter.search.elasticsearch.document.PostDocument;
-import dooya.see.domain.post.Post;
-import dooya.see.domain.post.Tag;
+import dooya.see.domain.post.*;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
 import java.util.stream.Collectors;
 
 @Component
@@ -26,5 +26,31 @@ public class PostDocumentMapper {
                 .createdAt(post.getMetaData().createdAt().toLocalDate())
                 .build();
 
+    }
+
+    public Post toDomain(PostDocument document) {
+        if (document == null) {
+            throw new IllegalArgumentException("");
+        }
+
+        PostMetaData metaData = new PostMetaData(
+                document.getCreatedAt().atStartOfDay(),
+                null,
+                null
+        );
+
+        List<Tag> tags = document.getTags().stream()
+                .map(Tag::new)
+                .toList();
+
+        return Post.fromSearchIndex(
+                Long.valueOf(document.getId()),
+                document.getTitle(),
+                document.getContent(),
+                PostCategory.valueOf(document.getCategory()),
+                document.getMemberId(),
+                tags,
+                metaData
+        );
     }
 }

--- a/src/main/java/dooya/see/adapter/search/elasticsearch/mapper/PostDocumentMapper.java
+++ b/src/main/java/dooya/see/adapter/search/elasticsearch/mapper/PostDocumentMapper.java
@@ -15,7 +15,7 @@ public class PostDocumentMapper {
         }
 
         return PostDocument.builder()
-                .id(post.getId())
+                .id(String.valueOf(post.getId()))
                 .title(post.getContent().title())
                 .content(post.getContent().body())
                 .category(post.getCategory().name())

--- a/src/main/java/dooya/see/adapter/search/elasticsearch/repository/PostSearchElasticsearchRepository.java
+++ b/src/main/java/dooya/see/adapter/search/elasticsearch/repository/PostSearchElasticsearchRepository.java
@@ -1,0 +1,10 @@
+package dooya.see.adapter.search.elasticsearch.repository;
+
+import dooya.see.adapter.search.elasticsearch.document.PostDocument;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+
+public interface PostSearchElasticsearchRepository extends ElasticsearchRepository<PostDocument, Long> {
+    Page<PostDocument> findByTitleContainingOrContentContaining(String title, String body, Pageable pageable);
+}

--- a/src/main/java/dooya/see/adapter/search/elasticsearch/repository/PostSearchElasticsearchRepository.java
+++ b/src/main/java/dooya/see/adapter/search/elasticsearch/repository/PostSearchElasticsearchRepository.java
@@ -5,6 +5,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
 
-public interface PostSearchElasticsearchRepository extends ElasticsearchRepository<PostDocument, Long> {
+public interface PostSearchElasticsearchRepository extends ElasticsearchRepository<PostDocument, String> {
     Page<PostDocument> findByTitleContainingOrContentContaining(String title, String body, Pageable pageable);
 }

--- a/src/main/java/dooya/see/adapter/webapi/PostSearchApi.java
+++ b/src/main/java/dooya/see/adapter/webapi/PostSearchApi.java
@@ -4,6 +4,7 @@ import dooya.see.adapter.webapi.dto.PostSearchRequest;
 import dooya.see.adapter.webapi.dto.PostSearchResponse;
 import dooya.see.application.post.dto.PostSearchResult;
 import dooya.see.application.post.provided.PostFinder;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -17,7 +18,7 @@ public class PostSearchApi {
     private final PostFinder postFinder;
 
     @GetMapping("/elasticsearch")
-    public Page<PostSearchResponse> search(PostSearchRequest request) {
+    public Page<PostSearchResponse> search(@Valid PostSearchRequest request) {
         Page<PostSearchResult> result = postFinder.searchPosts(request.keyword(), request.toPageable());
         return result.map(PostSearchResponse::from);
     }

--- a/src/main/java/dooya/see/adapter/webapi/PostSearchApi.java
+++ b/src/main/java/dooya/see/adapter/webapi/PostSearchApi.java
@@ -1,0 +1,24 @@
+package dooya.see.adapter.webapi;
+
+import dooya.see.adapter.webapi.dto.PostSearchRequest;
+import dooya.see.adapter.webapi.dto.PostSearchResponse;
+import dooya.see.application.post.dto.PostSearchResult;
+import dooya.see.application.post.provided.PostFinder;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/posts")
+public class PostSearchApi {
+    private final PostFinder postFinder;
+
+    @GetMapping("/elasticsearch")
+    public Page<PostSearchResponse> search(PostSearchRequest request) {
+        Page<PostSearchResult> result = postFinder.searchPosts(request.keyword(), request.toPageable());
+        return result.map(PostSearchResponse::from);
+    }
+}

--- a/src/main/java/dooya/see/adapter/webapi/dto/PostSearchRequest.java
+++ b/src/main/java/dooya/see/adapter/webapi/dto/PostSearchRequest.java
@@ -1,11 +1,16 @@
 package dooya.see.adapter.webapi.dto;
 
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
 public record PostSearchRequest(
         String keyword,
+        @Min(0)
         Integer page,
+        @Min(1)
+        @Max(100)
         Integer size
 ) {
     public Pageable toPageable() {

--- a/src/main/java/dooya/see/adapter/webapi/dto/PostSearchRequest.java
+++ b/src/main/java/dooya/see/adapter/webapi/dto/PostSearchRequest.java
@@ -1,0 +1,14 @@
+package dooya.see.adapter.webapi.dto;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+public record PostSearchRequest(
+        String keyword,
+        Integer page,
+        Integer size
+) {
+    public Pageable toPageable() {
+        return PageRequest.of(page != null ? page : 0, size != null ? size : 10);
+    }
+}

--- a/src/main/java/dooya/see/adapter/webapi/dto/PostSearchRequest.java
+++ b/src/main/java/dooya/see/adapter/webapi/dto/PostSearchRequest.java
@@ -7,11 +7,8 @@ import org.springframework.data.domain.Pageable;
 
 public record PostSearchRequest(
         String keyword,
-        @Min(0)
-        Integer page,
-        @Min(1)
-        @Max(100)
-        Integer size
+        @Min(0) Integer page,
+        @Min(1) @Max(100) Integer size
 ) {
     public Pageable toPageable() {
         return PageRequest.of(page != null ? page : 0, size != null ? size : 10);

--- a/src/main/java/dooya/see/adapter/webapi/dto/PostSearchResponse.java
+++ b/src/main/java/dooya/see/adapter/webapi/dto/PostSearchResponse.java
@@ -1,0 +1,21 @@
+package dooya.see.adapter.webapi.dto;
+
+import dooya.see.application.post.dto.PostSearchResult;
+
+public record PostSearchResponse(
+        Long id,
+        String title,
+        String content,
+        String category,
+        String authorNickname
+) {
+    public static PostSearchResponse from(PostSearchResult result) {
+        return new PostSearchResponse(
+                result.id(),
+                result.title(),
+                result.content(),
+                result.category() != null ? result.category().name() : null,
+                result.authorNickname()
+        );
+    }
+}

--- a/src/main/java/dooya/see/application/post/PostEventHandler.java
+++ b/src/main/java/dooya/see/application/post/PostEventHandler.java
@@ -1,0 +1,35 @@
+package dooya.see.application.post;
+
+import dooya.see.application.post.required.PostSearchIndexer;
+import dooya.see.domain.post.event.PostCreated;
+import dooya.see.domain.post.event.PostDeleted;
+import dooya.see.domain.post.event.PostUpdated;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PostEventHandler {
+    private final PostSearchIndexer postSearchIndexer;
+
+    @EventListener
+    public void handlePostCreated(PostCreated event) {
+        log.info("[ES] 게시글 생성 색인: {}", event.postId());
+        postSearchIndexer.index(event.post());
+    }
+
+    @EventListener
+    public void handlePostUpdated(PostUpdated event) {
+        log.info("[ES] 게시글 업데이트 색인: {}", event.postId());
+        postSearchIndexer.index(event.post());
+    }
+
+    @EventListener
+    public void handlePostDeleted(PostDeleted event) {
+        log.info("[ES] 게시글 색인 삭제: {}", event.postId());
+        postSearchIndexer.delete(event.postId());
+    }
+}

--- a/src/main/java/dooya/see/application/post/PostQueryService.java
+++ b/src/main/java/dooya/see/application/post/PostQueryService.java
@@ -1,9 +1,9 @@
 package dooya.see.application.post;
 
-import dooya.see.adapter.search.elasticsearch.document.PostDocument;
 import dooya.see.application.post.provided.PostFinder;
 import dooya.see.application.post.required.PostRepository;
 import dooya.see.application.post.required.PostSearchReader;
+import dooya.see.application.post.dto.PostSearchResult;
 import dooya.see.domain.post.*;
 import dooya.see.domain.post.dto.PostSearchRequest;
 import dooya.see.domain.post.exception.PostNotFoundException;
@@ -69,7 +69,7 @@ public class PostQueryService implements PostFinder {
     }
 
     @Override
-    public Page<PostDocument> searchPosts(String keyword, Pageable pageable) {
+    public Page<PostSearchResult> searchPosts(String keyword, Pageable pageable) {
         return postSearchReader.searchByKeyword(keyword, pageable);
     }
 

--- a/src/main/java/dooya/see/application/post/PostQueryService.java
+++ b/src/main/java/dooya/see/application/post/PostQueryService.java
@@ -2,6 +2,7 @@ package dooya.see.application.post;
 
 import dooya.see.application.post.provided.PostFinder;
 import dooya.see.application.post.required.PostRepository;
+import dooya.see.application.post.required.PostSearchReader;
 import dooya.see.domain.post.*;
 import dooya.see.domain.post.dto.PostSearchRequest;
 import dooya.see.domain.post.exception.PostNotFoundException;
@@ -20,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class PostQueryService implements PostFinder {
     private final PostRepository postRepository;
     private final ApplicationEventPublisher eventPublisher;
+    private final PostSearchReader postSearchReader;
 
     @Override
     public Post find(Long postId) {
@@ -63,6 +65,11 @@ public class PostQueryService implements PostFinder {
         }
 
         return search(searchRequest, pageable);
+    }
+
+    @Override
+    public Page<Post> searchPosts(String keyword, Pageable pageable) {
+        return postSearchReader.searchByKeyword(keyword, pageable);
     }
 
     @Override

--- a/src/main/java/dooya/see/application/post/PostQueryService.java
+++ b/src/main/java/dooya/see/application/post/PostQueryService.java
@@ -1,5 +1,6 @@
 package dooya.see.application.post;
 
+import dooya.see.adapter.search.elasticsearch.document.PostDocument;
 import dooya.see.application.post.provided.PostFinder;
 import dooya.see.application.post.required.PostRepository;
 import dooya.see.application.post.required.PostSearchReader;
@@ -68,7 +69,7 @@ public class PostQueryService implements PostFinder {
     }
 
     @Override
-    public Page<Post> searchPosts(String keyword, Pageable pageable) {
+    public Page<PostDocument> searchPosts(String keyword, Pageable pageable) {
         return postSearchReader.searchByKeyword(keyword, pageable);
     }
 

--- a/src/main/java/dooya/see/application/post/dto/PostSearchResult.java
+++ b/src/main/java/dooya/see/application/post/dto/PostSearchResult.java
@@ -1,0 +1,18 @@
+package dooya.see.application.post.dto;
+
+import dooya.see.domain.post.PostCategory;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record PostSearchResult(
+        Long id,
+        String title,
+        String content,
+        PostCategory category,
+        Long memberId,
+        String authorNickname,
+        List<String> tags,
+        LocalDate createdAt
+) {
+}

--- a/src/main/java/dooya/see/application/post/provided/PostFinder.java
+++ b/src/main/java/dooya/see/application/post/provided/PostFinder.java
@@ -76,4 +76,6 @@ public interface PostFinder {
     Post viewPost(Long postId, Long viewerId);
 
     Page<Post> findPosts(PostSearchRequest searchRequest, Pageable pageable);
+
+    Page<Post> searchPosts(String keyword, Pageable pageable);
 }

--- a/src/main/java/dooya/see/application/post/provided/PostFinder.java
+++ b/src/main/java/dooya/see/application/post/provided/PostFinder.java
@@ -1,5 +1,6 @@
 package dooya.see.application.post.provided;
 
+import dooya.see.adapter.search.elasticsearch.document.PostDocument;
 import dooya.see.domain.post.Post;
 import dooya.see.domain.post.PostCategory;
 import dooya.see.domain.post.PostStatus;
@@ -77,5 +78,5 @@ public interface PostFinder {
 
     Page<Post> findPosts(PostSearchRequest searchRequest, Pageable pageable);
 
-    Page<Post> searchPosts(String keyword, Pageable pageable);
+    Page<PostDocument> searchPosts(String keyword, Pageable pageable);
 }

--- a/src/main/java/dooya/see/application/post/provided/PostFinder.java
+++ b/src/main/java/dooya/see/application/post/provided/PostFinder.java
@@ -1,10 +1,10 @@
 package dooya.see.application.post.provided;
 
-import dooya.see.adapter.search.elasticsearch.document.PostDocument;
 import dooya.see.domain.post.Post;
 import dooya.see.domain.post.PostCategory;
 import dooya.see.domain.post.PostStatus;
 import dooya.see.domain.post.dto.PostSearchRequest;
+import dooya.see.application.post.dto.PostSearchResult;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -78,5 +78,5 @@ public interface PostFinder {
 
     Page<Post> findPosts(PostSearchRequest searchRequest, Pageable pageable);
 
-    Page<PostDocument> searchPosts(String keyword, Pageable pageable);
+    Page<PostSearchResult> searchPosts(String keyword, Pageable pageable);
 }

--- a/src/main/java/dooya/see/application/post/required/PostSearchIndexer.java
+++ b/src/main/java/dooya/see/application/post/required/PostSearchIndexer.java
@@ -1,0 +1,8 @@
+package dooya.see.application.post.required;
+
+import dooya.see.domain.post.Post;
+
+public interface PostSearchIndexer {
+    void index(Post post);
+    void delete(Long postId);
+}

--- a/src/main/java/dooya/see/application/post/required/PostSearchReader.java
+++ b/src/main/java/dooya/see/application/post/required/PostSearchReader.java
@@ -1,9 +1,9 @@
 package dooya.see.application.post.required;
 
-import dooya.see.domain.post.Post;
+import dooya.see.adapter.search.elasticsearch.document.PostDocument;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface PostSearchReader {
-    Page<Post> searchByKeyword(String keyword, Pageable pageable);
+    Page<PostDocument> searchByKeyword(String keyword, Pageable pageable);
 }

--- a/src/main/java/dooya/see/application/post/required/PostSearchReader.java
+++ b/src/main/java/dooya/see/application/post/required/PostSearchReader.java
@@ -1,9 +1,9 @@
 package dooya.see.application.post.required;
 
-import dooya.see.adapter.search.elasticsearch.document.PostDocument;
+import dooya.see.application.post.dto.PostSearchResult;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface PostSearchReader {
-    Page<PostDocument> searchByKeyword(String keyword, Pageable pageable);
+    Page<PostSearchResult> searchByKeyword(String keyword, Pageable pageable);
 }

--- a/src/main/java/dooya/see/application/post/required/PostSearchReader.java
+++ b/src/main/java/dooya/see/application/post/required/PostSearchReader.java
@@ -1,0 +1,9 @@
+package dooya.see.application.post.required;
+
+import dooya.see.domain.post.Post;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface PostSearchReader {
+    Page<Post> searchByKeyword(String keyword, Pageable pageable);
+}

--- a/src/main/java/dooya/see/domain/post/Post.java
+++ b/src/main/java/dooya/see/domain/post/Post.java
@@ -112,7 +112,8 @@ public class Post extends AbstractAggregateRoot {
                 getId(),
                 memberId,
                 category,
-                status == PostStatus.PUBLISHED
+                status == PostStatus.PUBLISHED,
+                this
         ));
     }
 
@@ -202,7 +203,8 @@ public class Post extends AbstractAggregateRoot {
                 contentResult.titleChanged(),
                 contentResult.bodyChanged(),
                 categoryChanged,
-                tagsChanged
+                tagsChanged,
+                this
         ));
     }
 

--- a/src/main/java/dooya/see/domain/post/Post.java
+++ b/src/main/java/dooya/see/domain/post/Post.java
@@ -1,6 +1,5 @@
 package dooya.see.domain.post;
 
-import dooya.see.domain.AbstractEntity;
 import dooya.see.domain.post.dto.PostCreateRequest;
 import dooya.see.domain.post.dto.PostUpdateRequest;
 import dooya.see.domain.post.event.*;
@@ -10,7 +9,6 @@ import dooya.see.domain.shared.AbstractAggregateRoot;
 import jakarta.persistence.*;
 import lombok.*;
 
-import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;

--- a/src/main/java/dooya/see/domain/post/Post.java
+++ b/src/main/java/dooya/see/domain/post/Post.java
@@ -107,35 +107,6 @@ public class Post extends AbstractAggregateRoot {
         return this.memberId.equals(memberId);
     }
 
-    public static Post fromSearchIndex(
-            Long id,
-            String title,
-            String content,
-            PostCategory category,
-            Long memberId,
-            List<Tag> tags,
-            PostMetaData metaData
-    ) {
-        Post post = Post.builder()
-                .content(new PostContent(title, content))
-                .category(category)
-                .memberId(memberId)
-                .tags(tags)
-                .metaData(metaData)
-                .status(PostStatus.PUBLISHED)
-                .build();
-
-        try {
-            Field idField = AbstractEntity.class.getDeclaredField("id");
-            idField.setAccessible(true);
-            idField.set(post, id);
-        } catch (Exception e) {
-            throw new IllegalStateException(e);
-        }
-
-        return post;
-    }
-
     // JPA 생명주기 콜백 - 생성 이벤트 발행
     @PostPersist
     private void publishCreationEvent() {

--- a/src/main/java/dooya/see/domain/post/Post.java
+++ b/src/main/java/dooya/see/domain/post/Post.java
@@ -1,5 +1,6 @@
 package dooya.see.domain.post;
 
+import dooya.see.domain.AbstractEntity;
 import dooya.see.domain.post.dto.PostCreateRequest;
 import dooya.see.domain.post.dto.PostUpdateRequest;
 import dooya.see.domain.post.event.*;
@@ -7,10 +8,9 @@ import dooya.see.domain.post.exception.InvalidPostStatusTransitionException;
 import dooya.see.domain.post.exception.UnauthorizedPostAccessException;
 import dooya.see.domain.shared.AbstractAggregateRoot;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -19,6 +19,8 @@ import static java.util.Objects.requireNonNull;
 
 @Entity
 @Getter
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Post extends AbstractAggregateRoot {
     @Embedded
@@ -103,6 +105,35 @@ public class Post extends AbstractAggregateRoot {
 
     public boolean isWrittenBy(Long memberId) {
         return this.memberId.equals(memberId);
+    }
+
+    public static Post fromSearchIndex(
+            Long id,
+            String title,
+            String content,
+            PostCategory category,
+            Long memberId,
+            List<Tag> tags,
+            PostMetaData metaData
+    ) {
+        Post post = Post.builder()
+                .content(new PostContent(title, content))
+                .category(category)
+                .memberId(memberId)
+                .tags(tags)
+                .metaData(metaData)
+                .status(PostStatus.PUBLISHED)
+                .build();
+
+        try {
+            Field idField = AbstractEntity.class.getDeclaredField("id");
+            idField.setAccessible(true);
+            idField.set(post, id);
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+
+        return post;
     }
 
     // JPA 생명주기 콜백 - 생성 이벤트 발행

--- a/src/main/java/dooya/see/domain/post/event/PostCreated.java
+++ b/src/main/java/dooya/see/domain/post/event/PostCreated.java
@@ -1,5 +1,6 @@
 package dooya.see.domain.post.event;
 
+import dooya.see.domain.post.Post;
 import dooya.see.domain.post.PostCategory;
 import dooya.see.domain.shared.DomainEvent;
 
@@ -7,5 +8,7 @@ public record PostCreated(
         Long postId,
         Long memberId,
         PostCategory category,
-        boolean publishImmediately
-) implements DomainEvent {}
+        boolean publishImmediately,
+        Post post
+) implements DomainEvent {
+}

--- a/src/main/java/dooya/see/domain/post/event/PostUpdated.java
+++ b/src/main/java/dooya/see/domain/post/event/PostUpdated.java
@@ -1,5 +1,6 @@
 package dooya.see.domain.post.event;
 
+import dooya.see.domain.post.Post;
 import dooya.see.domain.shared.DomainEvent;
 
 /**
@@ -11,5 +12,6 @@ public record PostUpdated(
     boolean titleChanged,
     boolean bodyChanged,
     boolean categoryChanged,
-    boolean tagsChanged
+    boolean tagsChanged,
+    Post post
 ) implements DomainEvent {}

--- a/src/test/java/dooya/see/HexagonalArchitectureTest.java
+++ b/src/test/java/dooya/see/HexagonalArchitectureTest.java
@@ -188,23 +188,8 @@ public class HexagonalArchitectureTest {
     @Nested
     class 명명_규칙_검증 {
         @Test
-        void 리포지토리_인터페이스는_적절한_접미사를_가져야_한다() {
-            assertThatRepositoryInterfacesFollowNamingConvention();
-        }
-
-        @Test
         void 애플리케이션_서비스는_Service로_끝나야_한다() {
             assertThatApplicationServicesFollowNamingConvention();
-        }
-
-        private void assertThatRepositoryInterfacesFollowNamingConvention() {
-            classes()
-                    .that().areInterfaces()
-                    .and().resideInAPackage(REQUIRED_PACKAGE)
-                    .should().haveSimpleNameEndingWith("Repository")
-                    .orShould().haveSimpleNameEndingWith("Manager")
-                    .because("리포지토리는 명확한 명명 규칙을 따라야 합니다")
-                    .check(classes);
         }
 
         private void assertThatApplicationServicesFollowNamingConvention() {

--- a/src/test/java/dooya/see/adapter/search/elasticsearch/PostSearchElasticsearchAdapterTest.java
+++ b/src/test/java/dooya/see/adapter/search/elasticsearch/PostSearchElasticsearchAdapterTest.java
@@ -56,7 +56,7 @@ record PostSearchElasticsearchAdapterTest(
     }
 
     @Test
-    void 존재하지_않는_회원이면_색인이_실패한다() {
+    void 존재하지_않는_회원이면_작성자_정보가_비어있다() {
         Post orphan = Post.create(createPostRequest(), 999L);
         setField(orphan, "id", 2L);
 

--- a/src/test/java/dooya/see/adapter/search/elasticsearch/PostSearchElasticsearchAdapterTest.java
+++ b/src/test/java/dooya/see/adapter/search/elasticsearch/PostSearchElasticsearchAdapterTest.java
@@ -1,0 +1,47 @@
+package dooya.see.adapter.search.elasticsearch;
+
+import dooya.see.adapter.search.elasticsearch.document.PostDocument;
+import dooya.see.adapter.search.elasticsearch.repository.PostSearchElasticsearchRepository;
+import dooya.see.domain.post.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static dooya.see.domain.post.PostFixture.createPostRequest;
+import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+@SpringBootTest
+record PostSearchElasticsearchAdapterTest(
+        PostSearchElasticsearchAdapter adapter,
+        PostSearchElasticsearchRepository repository) {
+    private static final Long AUTHOR_ID = 1L;
+
+    private static Post post;
+
+    @BeforeEach
+    void setUp() {
+        post = Post.create(createPostRequest(), AUTHOR_ID);
+        setField(post, "id", 1L);
+    }
+
+    @Test
+    void 게시글을_Elasticsearch_색인으로_저장한다() {
+        adapter.index(post);
+
+        PostDocument saved = repository.findById(post.getId()).orElseThrow();
+        assertThat(saved.getTitle()).isEqualTo("테스트 게시글 제목입니다");
+        assertThat(saved.getTags()).containsExactly("#spring", "#backend", "#java");
+    }
+
+    @Test
+    void 게시글_색인을_삭제한다() {
+        adapter.index(post);
+        assertThat(repository.existsById(post.getId())).isTrue();
+
+        adapter.delete(post.getId());
+
+        assertThat(repository.existsById(post.getId())).isFalse();
+    }
+}

--- a/src/test/java/dooya/see/adapter/search/elasticsearch/PostSearchElasticsearchAdapterTest.java
+++ b/src/test/java/dooya/see/adapter/search/elasticsearch/PostSearchElasticsearchAdapterTest.java
@@ -2,7 +2,12 @@ package dooya.see.adapter.search.elasticsearch;
 
 import dooya.see.adapter.search.elasticsearch.document.PostDocument;
 import dooya.see.adapter.search.elasticsearch.repository.PostSearchElasticsearchRepository;
-import dooya.see.domain.post.*;
+import dooya.see.application.member.required.MemberRepository;
+import dooya.see.domain.member.Member;
+import dooya.see.domain.member.MemberFixture;
+import dooya.see.domain.member.dto.MemberRegisterRequest;
+import dooya.see.domain.post.Post;
+import dooya.see.adapter.search.elasticsearch.document.PostDocument;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -14,14 +19,20 @@ import static org.springframework.test.util.ReflectionTestUtils.setField;
 @SpringBootTest
 record PostSearchElasticsearchAdapterTest(
         PostSearchElasticsearchAdapter adapter,
-        PostSearchElasticsearchRepository repository) {
-    private static final Long AUTHOR_ID = 1L;
-
+        PostSearchElasticsearchRepository repository,
+        MemberRepository memberRepository) {
     private static Post post;
+    private static Member savedMember;
 
     @BeforeEach
     void setUp() {
-        post = Post.create(createPostRequest(), AUTHOR_ID);
+        repository.deleteAll();
+
+        MemberRegisterRequest registerRequest = MemberFixture.createMemberRegisterRequest("member" + System.nanoTime() + "@see.com");
+        Member member = Member.register(registerRequest, MemberFixture.createPasswordEncoder());
+        savedMember = memberRepository.save(member);
+
+        post = Post.create(createPostRequest(), savedMember.getId());
         setField(post, "id", 1L);
     }
 
@@ -32,6 +43,7 @@ record PostSearchElasticsearchAdapterTest(
         PostDocument saved = repository.findById(post.getId()).orElseThrow();
         assertThat(saved.getTitle()).isEqualTo("테스트 게시글 제목입니다");
         assertThat(saved.getTags()).containsExactly("spring", "backend", "java");
+        assertThat(saved.getAuthorNickname()).isEqualTo(savedMember.getNickname());
     }
 
     @Test
@@ -42,5 +54,16 @@ record PostSearchElasticsearchAdapterTest(
         adapter.delete(post.getId());
 
         assertThat(repository.existsById(post.getId())).isFalse();
+    }
+
+    @Test
+    void 존재하지_않는_회원이면_색인이_실패한다() {
+        Post orphan = Post.create(createPostRequest(), 999L);
+        setField(orphan, "id", 2L);
+
+        adapter.index(orphan);
+
+        PostDocument indexed = repository.findById(2L).orElseThrow();
+        assertThat(indexed.getAuthorNickname()).isEmpty();
     }
 }

--- a/src/test/java/dooya/see/adapter/search/elasticsearch/PostSearchElasticsearchAdapterTest.java
+++ b/src/test/java/dooya/see/adapter/search/elasticsearch/PostSearchElasticsearchAdapterTest.java
@@ -7,7 +7,6 @@ import dooya.see.domain.member.Member;
 import dooya.see.domain.member.MemberFixture;
 import dooya.see.domain.member.dto.MemberRegisterRequest;
 import dooya.see.domain.post.Post;
-import dooya.see.adapter.search.elasticsearch.document.PostDocument;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -40,7 +39,7 @@ record PostSearchElasticsearchAdapterTest(
     void 게시글을_Elasticsearch_색인으로_저장한다() {
         adapter.index(post);
 
-        PostDocument saved = repository.findById(post.getId()).orElseThrow();
+        PostDocument saved = repository.findById(String.valueOf(post.getId())).orElseThrow();
         assertThat(saved.getTitle()).isEqualTo("테스트 게시글 제목입니다");
         assertThat(saved.getTags()).containsExactly("spring", "backend", "java");
         assertThat(saved.getAuthorNickname()).isEqualTo(savedMember.getNickname());
@@ -49,11 +48,11 @@ record PostSearchElasticsearchAdapterTest(
     @Test
     void 게시글_색인을_삭제한다() {
         adapter.index(post);
-        assertThat(repository.existsById(post.getId())).isTrue();
+        assertThat(repository.existsById(String.valueOf(post.getId()))).isTrue();
 
         adapter.delete(post.getId());
 
-        assertThat(repository.existsById(post.getId())).isFalse();
+        assertThat(repository.existsById(String.valueOf(post.getId()))).isFalse();
     }
 
     @Test
@@ -63,7 +62,7 @@ record PostSearchElasticsearchAdapterTest(
 
         adapter.index(orphan);
 
-        PostDocument indexed = repository.findById(2L).orElseThrow();
+        PostDocument indexed = repository.findById(String.valueOf(2L)).orElseThrow();
         assertThat(indexed.getAuthorNickname()).isEmpty();
     }
 }

--- a/src/test/java/dooya/see/adapter/search/elasticsearch/PostSearchElasticsearchAdapterTest.java
+++ b/src/test/java/dooya/see/adapter/search/elasticsearch/PostSearchElasticsearchAdapterTest.java
@@ -31,7 +31,7 @@ record PostSearchElasticsearchAdapterTest(
 
         PostDocument saved = repository.findById(post.getId()).orElseThrow();
         assertThat(saved.getTitle()).isEqualTo("테스트 게시글 제목입니다");
-        assertThat(saved.getTags()).containsExactly("#spring", "#backend", "#java");
+        assertThat(saved.getTags()).containsExactly("spring", "backend", "java");
     }
 
     @Test

--- a/src/test/java/dooya/see/adapter/search/elasticsearch/PostSearchElasticsearchAdapterTest.java
+++ b/src/test/java/dooya/see/adapter/search/elasticsearch/PostSearchElasticsearchAdapterTest.java
@@ -8,7 +8,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import static dooya.see.domain.post.PostFixture.createPostRequest;
-import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.util.ReflectionTestUtils.setField;
 

--- a/src/test/java/dooya/see/adapter/search/elasticsearch/PostSearchElasticsearchReaderAdapterTest.java
+++ b/src/test/java/dooya/see/adapter/search/elasticsearch/PostSearchElasticsearchReaderAdapterTest.java
@@ -31,6 +31,7 @@ record PostSearchElasticsearchReaderAdapterTest(
                         .content("Spring Boot 프로젝트에서 Elasticsearch 적용 경험기입니다.")
                         .category(PostCategory.TECH.name())
                         .memberId(1L)
+                        .authorNickname("작성자1")
                         .tags(List.of("Spring", "Elasticsearch"))
                         .createdAt(LocalDate.now())
                         .build(),
@@ -40,6 +41,7 @@ record PostSearchElasticsearchReaderAdapterTest(
                         .content("스레드와 동시성 제어의 기본을 다룹니다.")
                         .category(PostCategory.TECH.name())
                         .memberId(2L)
+                        .authorNickname("작성자2")
                         .tags(List.of("Java", "Thread"))
                         .createdAt(LocalDate.now())
                         .build()
@@ -56,5 +58,6 @@ record PostSearchElasticsearchReaderAdapterTest(
         assertThat(result).isNotEmpty();
         assertThat(result.getContent().get(0).title()).contains("Spring");
         assertThat(result.getContent().get(0).category()).isEqualTo(PostCategory.TECH);
+        assertThat(result.getContent().get(0).authorNickname()).isEqualTo("작성자1");
     }
 }

--- a/src/test/java/dooya/see/adapter/search/elasticsearch/PostSearchElasticsearchReaderAdapterTest.java
+++ b/src/test/java/dooya/see/adapter/search/elasticsearch/PostSearchElasticsearchReaderAdapterTest.java
@@ -1,9 +1,8 @@
 package dooya.see.adapter.search.elasticsearch;
 
 import dooya.see.adapter.search.elasticsearch.document.PostDocument;
-import dooya.see.adapter.search.elasticsearch.mapper.PostDocumentMapper;
 import dooya.see.adapter.search.elasticsearch.repository.PostSearchElasticsearchRepository;
-import dooya.see.domain.post.Post;
+import dooya.see.application.post.dto.PostSearchResult;
 import dooya.see.domain.post.PostCategory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -19,7 +18,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SpringBootTest
 record PostSearchElasticsearchReaderAdapterTest(
         PostSearchElasticsearchRepository repository,
-        PostDocumentMapper mapper,
         PostSearchElasticsearchReaderAdapter reader) {
 
     @BeforeEach
@@ -53,10 +51,10 @@ record PostSearchElasticsearchReaderAdapterTest(
         String keyword = "Spring";
         PageRequest pageable = PageRequest.of(0, 10);
 
-        Page<PostDocument> result = reader.searchByKeyword(keyword, pageable);
+        Page<PostSearchResult> result = reader.searchByKeyword(keyword, pageable);
 
         assertThat(result).isNotEmpty();
-        assertThat(result.getContent().get(0).getTitle()).contains("Spring");
-        assertThat(result.getContent().get(0).getCategory()).isEqualTo(PostCategory.TECH.name());
+        assertThat(result.getContent().get(0).title()).contains("Spring");
+        assertThat(result.getContent().get(0).category()).isEqualTo(PostCategory.TECH);
     }
 }

--- a/src/test/java/dooya/see/adapter/search/elasticsearch/PostSearchElasticsearchReaderAdapterTest.java
+++ b/src/test/java/dooya/see/adapter/search/elasticsearch/PostSearchElasticsearchReaderAdapterTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -18,7 +19,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SpringBootTest
 record PostSearchElasticsearchReaderAdapterTest(
         PostSearchElasticsearchRepository repository,
-        PostSearchElasticsearchReaderAdapter reader) {
+        PostSearchElasticsearchReaderAdapter reader,
+        ElasticsearchOperations operations) {
 
     @BeforeEach
     void setUp() {
@@ -46,6 +48,8 @@ record PostSearchElasticsearchReaderAdapterTest(
                         .createdAt(LocalDate.now())
                         .build()
         ));
+
+        operations.indexOps(PostDocument.class).refresh();
     }
 
     @Test

--- a/src/test/java/dooya/see/adapter/search/elasticsearch/PostSearchElasticsearchReaderAdapterTest.java
+++ b/src/test/java/dooya/see/adapter/search/elasticsearch/PostSearchElasticsearchReaderAdapterTest.java
@@ -1,0 +1,62 @@
+package dooya.see.adapter.search.elasticsearch;
+
+import dooya.see.adapter.search.elasticsearch.document.PostDocument;
+import dooya.see.adapter.search.elasticsearch.mapper.PostDocumentMapper;
+import dooya.see.adapter.search.elasticsearch.repository.PostSearchElasticsearchRepository;
+import dooya.see.domain.post.Post;
+import dooya.see.domain.post.PostCategory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+record PostSearchElasticsearchReaderAdapterTest(
+        PostSearchElasticsearchRepository repository,
+        PostDocumentMapper mapper,
+        PostSearchElasticsearchReaderAdapter reader) {
+
+    @BeforeEach
+    void setUp() {
+        repository.deleteAll();
+
+        repository.saveAll(List.of(
+                PostDocument.builder()
+                        .id(String.valueOf(1L))
+                        .title("Spring Elasticsearch 적용기")
+                        .content("Spring Boot 프로젝트에서 Elasticsearch 적용 경험기입니다.")
+                        .category(PostCategory.TECH.name())
+                        .memberId(1L)
+                        .tags(List.of("Spring", "Elasticsearch"))
+                        .createdAt(LocalDate.now())
+                        .build(),
+                PostDocument.builder()
+                        .id(String.valueOf(2L))
+                        .title("Java Concurrency 기초")
+                        .content("스레드와 동시성 제어의 기본을 다룹니다.")
+                        .category(PostCategory.TECH.name())
+                        .memberId(2L)
+                        .tags(List.of("Java", "Thread"))
+                        .createdAt(LocalDate.now())
+                        .build()
+        ));
+    }
+
+    @Test
+    void 제목과_내용을_기준으로_게시글을_검색한다() {
+        String keyword = "Spring";
+        PageRequest pageable = PageRequest.of(0, 10);
+
+        Page<Post> result = reader.searchByKeyword(keyword, pageable);
+
+        assertThat(result).isNotEmpty();
+        assertThat(result.getContent().get(0).getContent().title()).contains("Spring");
+        assertThat(result.getContent().get(0).getCategory()).isEqualTo(PostCategory.TECH);
+    }
+}

--- a/src/test/java/dooya/see/adapter/search/elasticsearch/PostSearchElasticsearchReaderAdapterTest.java
+++ b/src/test/java/dooya/see/adapter/search/elasticsearch/PostSearchElasticsearchReaderAdapterTest.java
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -19,8 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SpringBootTest
 record PostSearchElasticsearchReaderAdapterTest(
         PostSearchElasticsearchRepository repository,
-        PostSearchElasticsearchReaderAdapter reader,
-        ElasticsearchOperations operations) {
+        PostSearchElasticsearchReaderAdapter reader) {
 
     @BeforeEach
     void setUp() {
@@ -48,8 +46,6 @@ record PostSearchElasticsearchReaderAdapterTest(
                         .createdAt(LocalDate.now())
                         .build()
         ));
-
-        operations.indexOps(PostDocument.class).refresh();
     }
 
     @Test

--- a/src/test/java/dooya/see/adapter/search/elasticsearch/PostSearchElasticsearchReaderAdapterTest.java
+++ b/src/test/java/dooya/see/adapter/search/elasticsearch/PostSearchElasticsearchReaderAdapterTest.java
@@ -53,10 +53,10 @@ record PostSearchElasticsearchReaderAdapterTest(
         String keyword = "Spring";
         PageRequest pageable = PageRequest.of(0, 10);
 
-        Page<Post> result = reader.searchByKeyword(keyword, pageable);
+        Page<PostDocument> result = reader.searchByKeyword(keyword, pageable);
 
         assertThat(result).isNotEmpty();
-        assertThat(result.getContent().get(0).getContent().title()).contains("Spring");
-        assertThat(result.getContent().get(0).getCategory()).isEqualTo(PostCategory.TECH);
+        assertThat(result.getContent().get(0).getTitle()).contains("Spring");
+        assertThat(result.getContent().get(0).getCategory()).isEqualTo(PostCategory.TECH.name());
     }
 }

--- a/src/test/java/dooya/see/adapter/search/elasticsearch/mapper/PostDocumentMapperTest.java
+++ b/src/test/java/dooya/see/adapter/search/elasticsearch/mapper/PostDocumentMapperTest.java
@@ -1,0 +1,96 @@
+package dooya.see.adapter.search.elasticsearch.mapper;
+
+import dooya.see.adapter.search.elasticsearch.document.PostDocument;
+import dooya.see.application.post.dto.PostSearchResult;
+import dooya.see.domain.post.Post;
+import dooya.see.domain.post.PostCategory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static dooya.see.domain.post.PostFixture.createPostRequest;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class PostDocumentMapperTest {
+    private PostDocumentMapper mapper;
+    private Post post;
+
+    @BeforeEach
+    void setUp() {
+        mapper = new PostDocumentMapper();
+        post = Post.create(createPostRequest(), 1L);
+        ReflectionTestUtils.setField(post, "id", 10L);
+    }
+
+    @Test
+    void toDocument는_Post를_PostDocument로_변환한다() {
+        PostDocument document = mapper.toDocument(post, "author");
+
+        assertThat(document.getId()).isEqualTo("10");
+        assertThat(document.getTitle()).isEqualTo(post.getContent().title());
+        assertThat(document.getAuthorNickname()).isEqualTo("author");
+        assertThat(document.getTags()).containsExactly("spring", "backend", "java");
+    }
+
+    @Test
+    void toDocument는_null_Post면_예외를던진다() {
+        assertThatThrownBy(() -> mapper.toDocument(null, "author"))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("게시글 정보는 필수입니다");
+    }
+
+    @Test
+    void toDocument는_null_작성자면_예외를던진다() {
+        assertThatThrownBy(() -> mapper.toDocument(post, null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("작성자 닉네임은 필수입니다");
+    }
+
+    @Test
+    void toSearchResult는_PostDocument를_PostSearchResult로_변환한다() {
+        PostDocument document = PostDocument.builder()
+                .id("11")
+                .title("테스트")
+                .content("본문")
+                .category(PostCategory.TECH.name())
+                .memberId(2L)
+                .authorNickname("작성자")
+                .tags(List.of("spring"))
+                .createdAt(LocalDate.now())
+                .build();
+
+        PostSearchResult result = mapper.toSearchResult(document);
+
+        assertThat(result.id()).isEqualTo(11L);
+        assertThat(result.category()).isEqualTo(PostCategory.TECH);
+        assertThat(result.tags()).containsExactly("spring");
+    }
+
+    @Test
+    void toSearchResult는_Id가_숫자가_아니면_예외를던진다() {
+        PostDocument document = PostDocument.builder()
+                .id("abc")
+                .title("테스트")
+                .content("본문")
+                .category(PostCategory.TECH.name())
+                .memberId(2L)
+                .authorNickname("작성자")
+                .createdAt(LocalDate.now())
+                .build();
+
+        assertThatThrownBy(() -> mapper.toSearchResult(document))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("검색 문서 ID는 숫자여야 합니다");
+    }
+
+    @Test
+    void toSearchResult는_null_Document면_예외를던진다() {
+        assertThatThrownBy(() -> mapper.toSearchResult(null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("검색 문서는 필수입니다");
+    }
+}

--- a/src/test/java/dooya/see/adapter/search/elasticsearch/repository/PostSearchElasticsearchRepositoryTest.java
+++ b/src/test/java/dooya/see/adapter/search/elasticsearch/repository/PostSearchElasticsearchRepositoryTest.java
@@ -18,7 +18,7 @@ record PostSearchElasticsearchRepositoryTest(PostSearchElasticsearchRepository r
     void ElasticSearch_색인_저장_및_조회_테스트() {
         for (int i = 1; i <= 30; i++) {
             PostDocument document = new PostDocument(
-                    (long) i,
+                    String.valueOf((long) i),
                     "테스트 제목 " + i,
                     "본문 내용 " + i,
                     "TECH",

--- a/src/test/java/dooya/see/adapter/search/elasticsearch/repository/PostSearchElasticsearchRepositoryTest.java
+++ b/src/test/java/dooya/see/adapter/search/elasticsearch/repository/PostSearchElasticsearchRepositoryTest.java
@@ -23,6 +23,7 @@ record PostSearchElasticsearchRepositoryTest(PostSearchElasticsearchRepository r
                     "본문 내용 " + i,
                     "TECH",
                     1L,
+                    "작성자",
                     List.of("spring", "elasticsearch"),
                     LocalDate.now()
             );

--- a/src/test/java/dooya/see/adapter/search/elasticsearch/repository/PostSearchElasticsearchRepositoryTest.java
+++ b/src/test/java/dooya/see/adapter/search/elasticsearch/repository/PostSearchElasticsearchRepositoryTest.java
@@ -24,8 +24,7 @@ record PostSearchElasticsearchRepositoryTest(PostSearchElasticsearchRepository r
                     "TECH",
                     1L,
                     List.of("spring", "elasticsearch"),
-                    LocalDate.now(),
-                    LocalDate.now().plusDays(1)
+                    LocalDate.now()
             );
             repository.save(document);
         }

--- a/src/test/java/dooya/see/adapter/search/elasticsearch/repository/PostSearchElasticsearchRepositoryTest.java
+++ b/src/test/java/dooya/see/adapter/search/elasticsearch/repository/PostSearchElasticsearchRepositoryTest.java
@@ -6,7 +6,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -14,9 +13,7 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
-record PostSearchElasticsearchRepositoryTest(
-        PostSearchElasticsearchRepository repository,
-        ElasticsearchOperations operations) {
+record PostSearchElasticsearchRepositoryTest(PostSearchElasticsearchRepository repository) {
     @Test
     void ElasticSearch_색인_저장_및_조회_테스트() {
         repository.deleteAll();
@@ -34,8 +31,6 @@ record PostSearchElasticsearchRepositoryTest(
             );
             repository.save(document);
         }
-
-        operations.indexOps(PostDocument.class).refresh();
 
         Pageable pageable = PageRequest.of(0, 10);
 

--- a/src/test/java/dooya/see/adapter/search/elasticsearch/repository/PostSearchElasticsearchRepositoryTest.java
+++ b/src/test/java/dooya/see/adapter/search/elasticsearch/repository/PostSearchElasticsearchRepositoryTest.java
@@ -1,0 +1,43 @@
+package dooya.see.adapter.search.elasticsearch.repository;
+
+import dooya.see.adapter.search.elasticsearch.document.PostDocument;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+record PostSearchElasticsearchRepositoryTest(PostSearchElasticsearchRepository repository) {
+    @Test
+    void ElasticSearch_색인_저장_및_조회_테스트() {
+        for (int i = 1; i <= 30; i++) {
+            PostDocument document = new PostDocument(
+                    (long) i,
+                    "테스트 제목 " + i,
+                    "본문 내용 " + i,
+                    "TECH",
+                    1L,
+                    List.of("spring", "elasticsearch"),
+                    LocalDate.now(),
+                    LocalDate.now().plusDays(1)
+            );
+            repository.save(document);
+        }
+
+        Pageable pageable = PageRequest.of(0, 10);
+
+        Page<PostDocument> result =
+                repository.findByTitleContainingOrContentContaining("테스트", "테스트", pageable);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getContent()).hasSize(10);
+        assertThat(result.getTotalElements()).isGreaterThan(10);
+        assertThat(result.getContent().get(0).getTitle()).contains("테스트");
+    }
+}

--- a/src/test/java/dooya/see/adapter/search/elasticsearch/repository/PostSearchElasticsearchRepositoryTest.java
+++ b/src/test/java/dooya/see/adapter/search/elasticsearch/repository/PostSearchElasticsearchRepositoryTest.java
@@ -16,6 +16,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 record PostSearchElasticsearchRepositoryTest(PostSearchElasticsearchRepository repository) {
     @Test
     void ElasticSearch_색인_저장_및_조회_테스트() {
+        repository.deleteAll();
+
         for (int i = 1; i <= 30; i++) {
             PostDocument document = new PostDocument(
                     String.valueOf((long) i),
@@ -39,5 +41,6 @@ record PostSearchElasticsearchRepositoryTest(PostSearchElasticsearchRepository r
         assertThat(result.getContent()).hasSize(10);
         assertThat(result.getTotalElements()).isGreaterThan(10);
         assertThat(result.getContent().get(0).getTitle()).contains("테스트");
+        assertThat(result.getContent().get(0).getAuthorNickname()).isEqualTo("작성자");
     }
 }

--- a/src/test/java/dooya/see/adapter/search/elasticsearch/repository/PostSearchElasticsearchRepositoryTest.java
+++ b/src/test/java/dooya/see/adapter/search/elasticsearch/repository/PostSearchElasticsearchRepositoryTest.java
@@ -6,6 +6,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -13,7 +14,9 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
-record PostSearchElasticsearchRepositoryTest(PostSearchElasticsearchRepository repository) {
+record PostSearchElasticsearchRepositoryTest(
+        PostSearchElasticsearchRepository repository,
+        ElasticsearchOperations operations) {
     @Test
     void ElasticSearch_색인_저장_및_조회_테스트() {
         repository.deleteAll();
@@ -31,6 +34,8 @@ record PostSearchElasticsearchRepositoryTest(PostSearchElasticsearchRepository r
             );
             repository.save(document);
         }
+
+        operations.indexOps(PostDocument.class).refresh();
 
         Pageable pageable = PageRequest.of(0, 10);
 

--- a/src/test/java/dooya/see/adapter/webapi/PostApiTest.java
+++ b/src/test/java/dooya/see/adapter/webapi/PostApiTest.java
@@ -2,9 +2,12 @@ package dooya.see.adapter.webapi;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.JsonNode;
+import dooya.see.adapter.search.elasticsearch.repository.PostSearchElasticsearchRepository;
 import dooya.see.adapter.webapi.dto.MemberAuthResponse;
 import dooya.see.adapter.webapi.dto.PostCreateResponse;
 import dooya.see.adapter.webapi.dto.PostDetailResponse;
+import dooya.see.adapter.webapi.dto.PostSearchResponse;
 import dooya.see.application.member.provided.MemberRegister;
 import dooya.see.application.post.provided.PostFinder;
 import dooya.see.application.post.provided.PostStatsManager;
@@ -23,6 +26,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.assertj.MockMvcTester;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.test.web.servlet.assertj.MvcTestResult;
 import org.springframework.transaction.PlatformTransactionManager;
@@ -31,6 +35,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionTemplate;
 
 import java.io.UnsupportedEncodingException;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.function.BooleanSupplier;
@@ -53,6 +58,7 @@ class PostApiTest {
     final PostStatsManager postStatsManager;
     final PostFinder postFinder;
     final PlatformTransactionManager transactionManager;
+    final PostSearchElasticsearchRepository postSearchElasticsearchRepository;
 
     private String authorToken;
     private String readerToken;
@@ -61,6 +67,7 @@ class PostApiTest {
     void setUp() throws JsonProcessingException, UnsupportedEncodingException {
         authorToken = createMemberAndGetToken();
         readerToken = createSecondMemberAndGetToken();
+        postSearchElasticsearchRepository.deleteAll();
     }
 
     @Nested
@@ -782,6 +789,40 @@ class PostApiTest {
         }
     }
 
+    @Nested
+    class 게시글_검색_ES {
+        @Test
+        void 키워드로_게시글을_검색한다() throws Exception {
+            createPublishedPostWithTitle("Spring Boot Elasticsearch 연동");
+            createPublishedPostWithTitle("Java Stream 기초");
+            awaitSearchIndexed("Spring", 1);
+
+            MvcTestResult result = performPostSearchEs("Spring", 0, 10);
+
+            PageResponse<PostSearchResponse> page = parsePostSearchResponse(result);
+            assertThat(page.content()).extracting(PostSearchResponse::title)
+                    .contains("Spring Boot Elasticsearch 연동");
+        }
+
+        @Test
+        void 검색_결과가_없으면_빈_페이지를_반환한다() throws Exception {
+            createPublishedPostWithTitle("Spring Boot 가이드");
+            awaitSearchIndexed("Spring", 1);
+
+            MvcTestResult result = performPostSearchEs("Python", 0, 10);
+
+            PageResponse<PostSearchResponse> page = parsePostSearchResponse(result);
+            assertThat(page.content()).isEmpty();
+            assertThat(page.totalElements()).isZero();
+        }
+    }
+
+    private void awaitSearchIndexed(String keyword, int expectedCount) {
+        waitUntil(() -> executeInRequiresNewTransaction(() ->
+                postFinder.searchPosts(keyword, PageRequest.of(0, expectedCount)).getTotalElements() >= expectedCount),
+                "Elasticsearch indexing not completed for keyword=" + keyword);
+    }
+
     private void awaitPostStatsInitialized(Long postId) {
         waitUntil(() -> executeInRequiresNewTransaction(() -> postStatsRepository.findByPostId(postId).isPresent()),
                 "PostStats not initialized for postId=" + postId);
@@ -855,6 +896,19 @@ class PostApiTest {
 
     private Long createTestPublishedPost() throws JsonProcessingException, UnsupportedEncodingException {
         PostCreateRequest createRequest = createPostRequest(true);
+        String requestJson = objectMapper.writeValueAsString(createRequest);
+
+        MvcTestResult createResult = mvcTester.post().uri("/api/posts")
+                .header("Authorization", "Bearer " + authorToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestJson).exchange();
+
+        PostCreateResponse createResponse = parseResponse(createResult, PostCreateResponse.class);
+        return createResponse.postId();
+    }
+
+    private Long createPublishedPostWithTitle(String title) throws JsonProcessingException, UnsupportedEncodingException {
+        PostCreateRequest createRequest = createPostRequest(title, "검색용 본문");
         String requestJson = objectMapper.writeValueAsString(createRequest);
 
         MvcTestResult createResult = mvcTester.post().uri("/api/posts")
@@ -987,6 +1041,11 @@ class PostApiTest {
                 .exchange();
     }
 
+    private MvcTestResult performPostSearchEs(String keyword, int page, int size) {
+        String uri = String.format("/api/v1/posts/elasticsearch?keyword=%s&page=%d&size=%d", keyword, page, size);
+        return mvcTester.get().uri(uri).exchange();
+    }
+
     // 응답 파싱 헬퍼 메서드들
     private <T> T parseResponse(MvcTestResult result, Class<T> responseType)
             throws UnsupportedEncodingException, JsonProcessingException {
@@ -997,4 +1056,15 @@ class PostApiTest {
             throws UnsupportedEncodingException, JsonProcessingException {
         return objectMapper.readValue(result.getResponse().getContentAsString(), responseType);
     }
+
+    private PageResponse<PostSearchResponse> parsePostSearchResponse(MvcTestResult result)
+            throws UnsupportedEncodingException, JsonProcessingException {
+        JsonNode root = objectMapper.readTree(result.getResponse().getContentAsString());
+        PostSearchResponse[] content = objectMapper.treeToValue(root.get("content"), PostSearchResponse[].class);
+        int totalPages = root.path("totalPages").asInt();
+        long totalElements = root.path("totalElements").asLong();
+        return new PageResponse<>(Arrays.asList(content), totalPages, totalElements);
+    }
+
+    private record PageResponse<T>(List<T> content, int totalPages, long totalElements) {}
 }

--- a/src/test/java/dooya/see/application/post/PostEventHandlerTest.java
+++ b/src/test/java/dooya/see/application/post/PostEventHandlerTest.java
@@ -23,6 +23,6 @@ record PostEventHandlerTest(
         Post post = postManager.create(createPostRequest(), AUTHOR_ID);
 
         await().atMost(Duration.ofSeconds(2)).untilAsserted(() ->
-                assertThat(searchRepository.findById(post.getId())).isPresent());
+                assertThat(searchRepository.findById(String.valueOf(post.getId()))).isPresent());
     }
 }

--- a/src/test/java/dooya/see/application/post/PostEventHandlerTest.java
+++ b/src/test/java/dooya/see/application/post/PostEventHandlerTest.java
@@ -1,0 +1,28 @@
+package dooya.see.application.post;
+
+import dooya.see.adapter.search.elasticsearch.repository.PostSearchElasticsearchRepository;
+import dooya.see.application.post.provided.PostManager;
+import dooya.see.domain.post.Post;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.Duration;
+
+import static dooya.see.domain.post.PostFixture.createPostRequest;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+@SpringBootTest
+record PostEventHandlerTest(
+        PostManager postManager,
+        PostSearchElasticsearchRepository searchRepository) {
+    private static final Long AUTHOR_ID = 1L;
+
+    @Test
+    void 게시글_생성시_자동으로_색인된다() {
+        Post post = postManager.create(createPostRequest(), AUTHOR_ID);
+
+        await().atMost(Duration.ofSeconds(2)).untilAsserted(() ->
+                assertThat(searchRepository.findById(post.getId())).isPresent());
+    }
+}

--- a/src/test/java/dooya/see/application/post/PostStatsEventHandlerTest.java
+++ b/src/test/java/dooya/see/application/post/PostStatsEventHandlerTest.java
@@ -3,6 +3,7 @@ package dooya.see.application.post;
 import dooya.see.SeeTestConfiguration;
 import dooya.see.application.post.provided.PostStatsManager;
 import dooya.see.application.post.required.PostStatsRepository;
+import dooya.see.domain.post.Post;
 import dooya.see.domain.post.PostStats;
 import dooya.see.domain.post.PostStatus;
 import dooya.see.domain.post.event.*;
@@ -30,12 +31,13 @@ record PostStatsEventHandlerTest(PostStatsEventHandler postStatsEventHandler,
     private static final Long MEMBER_ID = 1L;
     private static final Long ANOTHER_MEMBER_ID = 2L;
     private static final Long NON_EXISTENT_POST_ID = 999L;
+    private static Post post;
 
     @Nested
     class 게시물_생성_이벤트 {
         @Test
         void PostCreated_이벤트_처리_시_통계가_생성된다() {
-            PostCreated event = new PostCreated(POST_ID, MEMBER_ID, TECH, false);
+            PostCreated event = new PostCreated(POST_ID, MEMBER_ID, TECH, false, post);
 
             postStatsEventHandler.handlePostCreated(event);
 
@@ -243,7 +245,7 @@ record PostStatsEventHandlerTest(PostStatsEventHandler postStatsEventHandler,
     class 기타_이벤트_처리 {
         @Test
         void PostUpdated_이벤트는_조용히_처리된다() {
-            PostUpdated event = new PostUpdated(POST_ID, MEMBER_ID, true, false, true, true);
+            PostUpdated event = new PostUpdated(POST_ID, MEMBER_ID, true, false, true, true, post);
 
             assertThatCode(() -> postStatsEventHandler.handlePostUpdated(event))
                     .doesNotThrowAnyException();

--- a/src/test/java/dooya/see/application/post/provided/PostFinderTest.java
+++ b/src/test/java/dooya/see/application/post/provided/PostFinderTest.java
@@ -1,6 +1,7 @@
 package dooya.see.application.post.provided;
 
 import dooya.see.SeeTestConfiguration;
+import dooya.see.adapter.search.elasticsearch.repository.PostSearchElasticsearchRepository;
 import dooya.see.domain.post.Post;
 import dooya.see.domain.post.PostCategory;
 import dooya.see.domain.post.dto.PostSearchRequest;
@@ -20,13 +21,18 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 
 import static dooya.see.domain.post.PostFixture.*;
+import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SpringBootTest
 @Transactional
 @Import(SeeTestConfiguration.class)
-record PostFinderTest(PostFinder postFinder, PostManager postManager, EntityManager entityManager) {
+record PostFinderTest(
+        PostFinder postFinder,
+        PostManager postManager,
+        EntityManager entityManager,
+        PostSearchElasticsearchRepository repository) {
     private static final Long AUTHOR_ID = 1L;
     private static final Long ANOTHER_AUTHOR_ID = 2L;
     private static final Long VIEWER_ID = 2L;
@@ -34,6 +40,7 @@ record PostFinderTest(PostFinder postFinder, PostManager postManager, EntityMana
     @BeforeEach
     void setUp() {
         entityManager.clear();
+        repository.deleteAll();
     }
 
     @Nested
@@ -300,6 +307,43 @@ record PostFinderTest(PostFinder postFinder, PostManager postManager, EntityMana
             assertThat(posts).hasSize(expectedTitles.length);
             assertThat(posts).extracting(post -> post.getContent().title())
                     .containsExactlyInAnyOrder(expectedTitles);
+        }
+    }
+
+    @Nested
+    class 게시글_검색_ES {
+        @Test
+        void Elasticsearch에서_게시글을_키워드로_검색한다() {
+            createTestPostWithTitle("Spring Boot Elasticsearch 연동");
+            createTestPostWithTitle("Java Stream 기초");
+            flushAndClearContext();
+
+            Page<Post> result = postFinder.searchPosts("Spring", PageRequest.of(0, 10));
+
+            assertThat(result).isNotEmpty();
+            assertThat(result.getContent().get(0).getContent().title()).contains("Spring");
+        }
+
+        @Test
+        void Elasticsearch에서_제목과_내용을_모두_검색한다() {
+            createTestPostWithContent("테스트 게시물", "Spring Framework를 다룹니다.");
+            createTestPostWithContent("Java 게시물", "JVM 메모리 구조를 다룹니다.");
+            flushAndClearContext();
+
+            Page<Post> result = postFinder.searchPosts("Spring", PageRequest.of(0, 10));
+
+            assertThat(result).hasSize(1);
+            assertThat(result.getContent().get(0).getContent().title()).contains("테스트 게시물");
+        }
+
+        @Test
+        void Elasticsearch에서_키워드가_없으면_빈_결과를_반환한다() {
+            createTestPostWithTitle("Java 입문");
+            flushAndClearContext();
+
+            Page<Post> result = postFinder.searchPosts("Python", PageRequest.of(0, 10));
+
+            assertThat(result).isEmpty();
         }
     }
 

--- a/src/test/java/dooya/see/application/post/provided/PostFinderTest.java
+++ b/src/test/java/dooya/see/application/post/provided/PostFinderTest.java
@@ -1,6 +1,7 @@
 package dooya.see.application.post.provided;
 
 import dooya.see.SeeTestConfiguration;
+import dooya.see.adapter.search.elasticsearch.document.PostDocument;
 import dooya.see.adapter.search.elasticsearch.repository.PostSearchElasticsearchRepository;
 import dooya.see.domain.post.Post;
 import dooya.see.domain.post.PostCategory;
@@ -21,7 +22,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 
 import static dooya.see.domain.post.PostFixture.*;
-import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -318,10 +318,11 @@ record PostFinderTest(
             createTestPostWithTitle("Java Stream 기초");
             flushAndClearContext();
 
-            Page<Post> result = postFinder.searchPosts("Spring", PageRequest.of(0, 10));
+            Page<PostDocument> result = postFinder.searchPosts("Spring", PageRequest.of(0, 10));
 
             assertThat(result).isNotEmpty();
-            assertThat(result.getContent().get(0).getContent().title()).contains("Spring");
+            assertThat(result.getContent())
+                    .anyMatch(document -> document.getTitle().contains("Spring"));
         }
 
         @Test
@@ -330,10 +331,11 @@ record PostFinderTest(
             createTestPostWithContent("Java 게시물", "JVM 메모리 구조를 다룹니다.");
             flushAndClearContext();
 
-            Page<Post> result = postFinder.searchPosts("Spring", PageRequest.of(0, 10));
+            Page<PostDocument> result = postFinder.searchPosts("Spring", PageRequest.of(0, 10));
 
-            assertThat(result).hasSize(1);
-            assertThat(result.getContent().get(0).getContent().title()).contains("테스트 게시물");
+            assertThat(result.getContent())
+                    .extracting(PostDocument::getTitle)
+                    .contains("테스트 게시물");
         }
 
         @Test
@@ -341,7 +343,7 @@ record PostFinderTest(
             createTestPostWithTitle("Java 입문");
             flushAndClearContext();
 
-            Page<Post> result = postFinder.searchPosts("Python", PageRequest.of(0, 10));
+            Page<PostDocument> result = postFinder.searchPosts("Python", PageRequest.of(0, 10));
 
             assertThat(result).isEmpty();
         }

--- a/src/test/java/dooya/see/application/post/provided/PostFinderTest.java
+++ b/src/test/java/dooya/see/application/post/provided/PostFinderTest.java
@@ -1,7 +1,7 @@
 package dooya.see.application.post.provided;
 
 import dooya.see.SeeTestConfiguration;
-import dooya.see.adapter.search.elasticsearch.document.PostDocument;
+import dooya.see.application.post.dto.PostSearchResult;
 import dooya.see.adapter.search.elasticsearch.repository.PostSearchElasticsearchRepository;
 import dooya.see.domain.post.Post;
 import dooya.see.domain.post.PostCategory;
@@ -318,11 +318,11 @@ record PostFinderTest(
             createTestPostWithTitle("Java Stream 기초");
             flushAndClearContext();
 
-            Page<PostDocument> result = postFinder.searchPosts("Spring", PageRequest.of(0, 10));
+            Page<PostSearchResult> result = postFinder.searchPosts("Spring", PageRequest.of(0, 10));
 
             assertThat(result).isNotEmpty();
             assertThat(result.getContent())
-                    .anyMatch(document -> document.getTitle().contains("Spring"));
+                    .anyMatch(document -> document.title().contains("Spring"));
         }
 
         @Test
@@ -331,10 +331,10 @@ record PostFinderTest(
             createTestPostWithContent("Java 게시물", "JVM 메모리 구조를 다룹니다.");
             flushAndClearContext();
 
-            Page<PostDocument> result = postFinder.searchPosts("Spring", PageRequest.of(0, 10));
+            Page<PostSearchResult> result = postFinder.searchPosts("Spring", PageRequest.of(0, 10));
 
             assertThat(result.getContent())
-                    .extracting(PostDocument::getTitle)
+                    .extracting(PostSearchResult::title)
                     .contains("테스트 게시물");
         }
 
@@ -343,7 +343,7 @@ record PostFinderTest(
             createTestPostWithTitle("Java 입문");
             flushAndClearContext();
 
-            Page<PostDocument> result = postFinder.searchPosts("Python", PageRequest.of(0, 10));
+            Page<PostSearchResult> result = postFinder.searchPosts("Python", PageRequest.of(0, 10));
 
             assertThat(result).isEmpty();
         }


### PR DESCRIPTION
## 📌 Issue

<!-- 해결하려는 이슈 번호나 주제를 명확하게 적어주세요. -->

- closed #154 

---

## 🧐 현재 상황

<!-- 현재 발생한 문제, 개선이 필요한 사항을 간략히 설명해주세요. -->

- 개선이 필요한 사항을 간략히 설명해주세요.

---

## 🎯 목표

<!-- 이슈를 통해 달성하고자 하는 목표를 설명해주세요. -->

- Post 검색 Elasticsearch 도입

---

## 🛠 작업 내용

- 작업 할 내용을 입력해주세요.

- [x] Post 검색 Elasticsearch 도입
- [x] 테스트 작성

---

## 🚀 기타 사항

<!-- 리뷰어가 추가적으로 알아야 할 사항이 있다면 기재해주세요. -->

- 추가적인 내용을 작성해주세요.(참고 자료, 협업 내용)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 게시글을 키워드로 검색하는 Elasticsearch 기반 검색 API 추가 (/api/v1/posts/elasticsearch)
  * 검색 결과 페이지네이션 및 제목·본문 기준 검색 지원
  * 검색 결과에 작성자 닉네임, 태그, 카테고리, 작성일 노출

* **Bug Fixes**
  * 게시글 생성·수정·삭제 시 검색 인덱스가 이벤트 기반으로 자동 동기화되도록 개선

* **Chores**
  * 개발·CI 환경에 Elasticsearch 및 Kibana 서비스 추가 및 설정
  * 빌드에 Spring Data Elasticsearch 의존성 추가

* **Tests**
  * 검색 기능 및 인덱싱 동작을 검증하는 통합/단위 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->